### PR TITLE
/new_things improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,4 +100,6 @@ server.listen(https_port, function() {
   adapterManager.loadAdapters();
 });
 
+app._server = server;
+
 module.exports = app; // for testing

--- a/models/actions.js
+++ b/models/actions.js
@@ -64,8 +64,7 @@ var Actions = {
     action.status = 'pending';
     switch(action.name) {
       case 'pair':
-        AdapterManager.addNewThing().then(function(thing) {
-          Things.handleNewThing(thing);
+        AdapterManager.addNewThing().then(function() {
           action.status = 'completed';
         }).catch(function(error) {
           action.status = 'error';

--- a/models/things.js
+++ b/models/things.js
@@ -112,11 +112,9 @@ var Things = {
     * @param Object New Thing description
     */
    handleNewThing: function(newThing) {
-     var thing = new Thing(newThing.id, newThing);
-
      // Notify each open websocket of the new Thing
      this.websockets.forEach(function(socket) {
-       socket.send(JSON.stringify(thing.getDescription()));
+       socket.send(JSON.stringify(newThing));
      });
    },
 

--- a/models/things.js
+++ b/models/things.js
@@ -143,4 +143,8 @@ var Things = {
    }
  };
 
+AdapterManager.on('thing-added', function(thing) {
+  Things.handleNewThing(thing);
+});
+
 module.exports = Things;

--- a/test/common.js
+++ b/test/common.js
@@ -12,6 +12,7 @@
 /* globals assert */
 
 process.env.NODE_ENV = 'test';
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var chai = require('chai');
 global.chai = chai;


### PR DESCRIPTION
This fixes several issues with the behavior of /new_things. First, it updates `handleNewThing` to send the Thing instead of a description of the thing. This fixes a case where pairing a new device would be impossible due to the description's lack of its corresponding thing's id.

Second, it replaces the one-shot AdapterManager promise with a listener on 'thing-added' events. This is explained in more detail at https://github.com/moziot/gateway/pull/99#issuecomment-309088070 and #99 in general.

It finally adds a test for the updated behavior which will fail if either fix is not present.