### PR TITLE
Increase integration testing; Fix spec compliance of ActionsController

### DIFF
--- a/adapters/adapter.js
+++ b/adapters/adapter.js
@@ -65,9 +65,9 @@ class Adapter {
 
   asDict() {
     return {
-      'id': this.id,
-      'name': this.name,
-      'ready': this.ready,
+      'id': this.getId(),
+      'name': this.getName(),
+      'ready': this.isReady(),
     };
   }
 

--- a/app.js
+++ b/app.js
@@ -123,6 +123,7 @@ server.listen(port, function() {
   console.log('Listening on port', server.address().port);
 });
 
-app._server = server;
-
-module.exports = app; // for testing
+module.exports = { // for testing
+  app: app,
+  server: server
+};

--- a/app.js
+++ b/app.js
@@ -123,4 +123,6 @@ server.listen(port, function() {
   console.log('Listening on port', server.address().port);
 });
 
+app._server = server;
+
 module.exports = app; // for testing

--- a/controllers/adapters_controller.js
+++ b/controllers/adapters_controller.js
@@ -41,17 +41,4 @@ adaptersController.get('/:adapterId/', (request, response) => {
   }
 });
 
-/**
- * Get a particular adapter.
- */
-adaptersController.get('/:adapterId/:action', (request, response) => {
-  var adapterId = request.params.adapterId;
-  var adapter = adapterManager.getAdapter(adapterId);
-  if (adapter) {
-    response.json(adapter.asDict());
-  } else {
-    response.status(404).send('Adapter "' + adapterId + '" not found.');
-  }
-});
-
 module.exports = adaptersController;

--- a/models/actions.js
+++ b/models/actions.js
@@ -97,6 +97,7 @@ var Actions = {
         }
         break;
       default:
+        delete this.actions[id];
         throw 'Invalid action name: "' + action.name + '"';
     }
   },

--- a/models/actions.js
+++ b/models/actions.js
@@ -64,8 +64,7 @@ var Actions = {
     action.status = 'pending';
     switch(action.name) {
       case 'pair':
-        AdapterManager.addNewThing().then(function(thing) {
-          Things.handleNewThing(thing);
+        AdapterManager.addNewThing().then(function() {
           action.status = 'completed';
         }).catch(function(error) {
           action.status = 'error';

--- a/models/actions.js
+++ b/models/actions.js
@@ -47,10 +47,12 @@ var Actions = {
   /**
    * Get a list of all current actions.
    *
-   * @returns {Object} A map of current actions.
+   * @returns {Array} A list of current actions.
    */
   getAll: function() {
-    return this.actions;
+    return Object.keys(this.actions).map(id => {
+      return this.actions[id];
+    });
   },
 
   /**

--- a/models/things.js
+++ b/models/things.js
@@ -106,11 +106,9 @@ var Things = {
     * @param Object New Thing description
     */
    handleNewThing: function(newThing) {
-     var thing = new Thing(newThing.id, newThing);
-
      // Notify each open websocket of the new Thing
      this.websockets.forEach(function(socket) {
-       socket.send(JSON.stringify(thing.getDescription()));
+       socket.send(JSON.stringify(newThing));
      });
    },
 

--- a/models/things.js
+++ b/models/things.js
@@ -137,4 +137,8 @@ var Things = {
    }
  };
 
+AdapterManager.on('thing-added', function(thing) {
+  Things.handleNewThing(thing);
+});
+
 module.exports = Things;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "npm run lint && npm run mocha",
     "lint": "eslint .",
-    "mocha": "./test/run-tests.sh"
+    "mocha": "./test/run-tests.sh",
+    "cov": "nyc npm run mocha",
+    "cov-html": "nyc --reporter=html npm run mocha"
   },
   "repository": {
     "type": "git",
@@ -46,6 +48,7 @@
     "chai-http": "^3.0.0",
     "eslint": "^4.0.0",
     "mocha": "^3.4.2",
-    "node-rest-client": "^3.1.0"
+    "node-rest-client": "^3.1.0",
+    "nyc": "^11.0.2"
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -33,20 +33,7 @@ function mockAdapter() {
 }
 global.mockAdapter = mockAdapter;
 
-function rp(chaiRequest) {
-  return new Promise((resolve, reject) => {
-    chaiRequest.end((err, res) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(res);
-      }
-    });
-  });
-}
-global.rp = rp;
-
 module.exports = {
-  mockAdapter, server, chai, assert, expect, rp
+  mockAdapter, server, chai, assert, expect
 };
 

--- a/test/common.js
+++ b/test/common.js
@@ -9,6 +9,7 @@
 /* globals assert, expect */
 
 process.env.NODE_ENV = 'test';
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var chai = require('chai');
 global.chai = chai;

--- a/test/common.js
+++ b/test/common.js
@@ -33,6 +33,20 @@ function mockAdapter() {
 }
 global.mockAdapter = mockAdapter;
 
+function rp(chaiRequest) {
+  return new Promise((resolve, reject) => {
+    chaiRequest.end((err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+}
+global.rp = rp;
+
 module.exports = {
-  mockAdapter, server, chai, assert, expect
+  mockAdapter, server, chai, assert, expect, rp
 };
+

--- a/test/common.js
+++ b/test/common.js
@@ -20,8 +20,9 @@ let chaiHttp = require('chai-http');
 chai.should();
 chai.use(chaiHttp);
 
-var server = require('../app');
+let {server, app} = require('../app');
 global.server = server;
+global.app = app;
 
 var adapterManager = require('../adapter-manager');
 

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -8,179 +8,154 @@ const {server, chai, mockAdapter} = require('../common');
 var Constants = require('../../constants');
 const WebSocket = require('ws');
 
-it('removes all existing actions', done => {
+it('removes all existing actions', async () => {
 
-  chai.request(server)
-    .get(Constants.ACTIONS_PATH).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-
-    // Issue a request to delete all current actions
-    let deleteReqs = res.body.map(action => {
-      return chai.request(server)
-        .delete(Constants.ACTIONS_PATH + '/' + action.id);
-    });
-
-    return Promise.all(deleteReqs);
-  }).then(responses => {
-    for (let res of responses) {
-      res.should.have.status(204);
-    }
-
-    return chai.request(server)
-      .get(Constants.ACTIONS_PATH);
-  }).then(res => {
-    res.body.should.be.a('array');
-    res.body.length.should.be.eql(0);
-
-    done();
-  });
-});
-
-it('GET with no actions', (done) => {
-  chai.request(server)
+  let res = await chai.request(server)
     .get(Constants.ACTIONS_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.be.a('array');
-      res.body.length.should.be.eql(0);
-      done();
-    });
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+
+  // Issue a request to delete all current actions
+  let deleteReqs = res.body.map(action => {
+    return chai.request(server)
+      .delete(Constants.ACTIONS_PATH + '/' + action.id);
+  });
+
+  const responses = await Promise.all(deleteReqs);
+  for (let res of responses) {
+    res.should.have.status(204);
+  }
+
+  res = await chai.request(server)
+      .get(Constants.ACTIONS_PATH);
+
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(0);
 });
 
-it('should fail to create a new action (empty body)', (done) => {
-  chai.request(server)
-    .post(Constants.ACTIONS_PATH)
-    .send()
-    .end((err, res) => {
-      res.should.have.status(400);
-      done();
-    });
+it('GET with no actions', async () => {
+  const res = await chai.request(server)
+    .get(Constants.ACTIONS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(0);
 });
 
-it('should fail to create a new action (unknown name)', (done) => {
+it('should fail to create a new action (empty body)', async () => {
+  try {
+    await chai.request(server)
+      .post(Constants.ACTIONS_PATH)
+      .send();
+  } catch(err) {
+    err.response.should.have.status(400);
+  }
+});
+
+it('should fail to create a new action (unknown name)', async () => {
   let descr = {
     name: 'potato'
   };
-  chai.request(server)
-    .post(Constants.ACTIONS_PATH)
-    .send(descr)
-    .end((err, res) => {
-      res.should.have.status(400);
-      done();
-    });
+  try {
+    await chai.request(server)
+      .post(Constants.ACTIONS_PATH)
+      .send(descr);
+  } catch(err) {
+    err.response.should.have.status(400);
+  }
 });
 
-it('should create a new pairing action', (done) => {
+it('should create a new pairing action', async () => {
   let descr = {
     name: 'pair'
   };
-  chai.request(server)
+  const res = await chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send(descr)
-    .end((err, res) => {
-      res.should.have.status(201);
-      done();
-    });
+    .send(descr);
+
+  res.should.have.status(201);
 });
 
-it('should list and retrieve the new action', (done) => {
-  chai.request(server)
-    .get(Constants.ACTIONS_PATH).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    res.body.length.should.be.eql(1);
-    res.body[0].should.have.a.property('name');
-    res.body[0].should.have.a.property('id');
-    res.body[0].name.should.be.eql('pair');
+it('should list and retrieve the new action', async () => {
+  let res = await chai.request(server)
+    .get(Constants.ACTIONS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(1);
+  res.body[0].should.have.a.property('name');
+  res.body[0].should.have.a.property('id');
+  res.body[0].name.should.be.eql('pair');
 
-    return res.body[0].id;
-  }).then(actionId => {
-    return chai.request(server)
-      .get(Constants.ACTIONS_PATH + '/' + actionId);
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.have.a.property('name');
-    res.body.name.should.be.eql('pair');
-    res.body.should.have.a.property('id');
-
-    done();
-  });
+  const actionId = res.body[0].id;
+  res = await chai.request(server)
+    .get(Constants.ACTIONS_PATH + '/' + actionId);
+  res.should.have.status(200);
+  res.body.should.have.a.property('name');
+  res.body.name.should.be.eql('pair');
+  res.body.should.have.a.property('id');
 });
 
-it('should error retrieving a nonexistent action', (done) => {
+it('should error retrieving a nonexistent action', async () => {
   let actionId = 'tomato';
-  chai.request(server)
-    .get(Constants.ACTIONS_PATH + '/' + actionId).then(() => {
-    throw new Error('Response should be 404');
-  }).catch(err => {
+  try {
+    const res = await chai.request(server)
+      .get(Constants.ACTIONS_PATH + '/' + actionId);
+  } catch(err) {
     err.response.should.have.status(404);
-    done();
-  });
+  }
 });
 
-it('should remove an action', done => {
+it('should remove an action', async () => {
 
-  chai.request(server)
-    .get(Constants.ACTIONS_PATH).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    res.body.length.should.be.eql(1);
-    let actionId = res.body[0].id;
-    return actionId;
-  }).then(actionId => {
-    return chai.request(server)
-      .delete(Constants.ACTIONS_PATH + '/' + actionId);
-  }).then(res => {
-    res.should.have.status(204);
+  let res = await chai.request(server)
+    .get(Constants.ACTIONS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(1);
+  const actionId = res.body[0].id;
 
-    return chai.request(server)
-      .get(Constants.ACTIONS_PATH);
-  }).then(res => {
-    res.body.should.be.a('array');
-    res.body.length.should.be.eql(0);
+  res = await chai.request(server)
+    .delete(Constants.ACTIONS_PATH + '/' + actionId);
+  res.should.have.status(204);
 
-    done();
-  });
+  res = await chai.request(server)
+    .get(Constants.ACTIONS_PATH);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(0);
 });
 
-it('should error removing a nonexistent action', done => {
+it('should error removing a nonexistent action', async () => {
   let actionId = 555;
 
-  chai.request(server)
-    .delete(Constants.ACTIONS_PATH + '/' + actionId).then(res => {
-    throw new Error('Not a 404');
-  }).catch(err => {
+  try {
+    await chai.request(server)
+      .delete(Constants.ACTIONS_PATH + '/' + actionId);
+  } catch(err) {
     err.response.status.should.be.eql(404);
-    done();
-  });
+  }
 });
 
-it('should error on an unpair of a nonexistent device',
-   done => {
+it('should error on an unpair of a nonexistent device', async () => {
   let thingId = 'test-nonexistent';
   // The mock adapter requires knowing in advance that we're going to unpair
   // a specific device
   mockAdapter().unpairDevice(thingId);
 
-  chai.request(server)
+  let res = await chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send({name: 'unpair', parameters: {id: thingId}}).then(res => {
-    res.should.have.status(201);
-    return chai.request(server)
+    .send({name: 'unpair', parameters: {id: thingId}});
+  res.should.have.status(201);
+
+  res = await chai.request(server)
       .get(Constants.ACTIONS_PATH);
-  }).then(res => {
-    res.body.should.be.a('array');
-    res.body[0].should.have.a.property('name');
-    res.body[0].name.should.be.eql('unpair');
+  res.body.should.be.a('array');
+  res.body[0].should.have.a.property('name');
+  res.body[0].name.should.be.eql('unpair');
 
-    res.body[0].should.have.a.property('id');
+  res.body[0].should.have.a.property('id');
 
-    res.body[0].should.have.a.property('status');
-    res.body[0].status.should.be.eql('error');
+  res.body[0].should.have.a.property('status');
+  res.body[0].status.should.be.eql('error');
 
-    res.body[0].should.have.a.property('error');
-    done();
-  });
+  res.body[0].should.have.a.property('error');
 });
 

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -97,3 +97,32 @@ it('should remove an action', done => {
   });
 });
 
+
+it('should error on an unpair of a nonexistent device',
+   done => {
+  let thingId = 'test-nonexistent';
+  // The mock adapter requires knowing in advance that we're going to unpair
+  // a specific device
+  mockAdapter().unpairDevice(thingId);
+
+  rp(chai.request(server)
+    .post(Constants.ACTIONS_PATH)
+    .send({name: 'unpair', parameters: {id: thingId}})).then(res => {
+    res.should.have.status(201);
+    return rp(chai.request(server)
+      .get(Constants.ACTIONS_PATH));
+  }).then(res => {
+    res.body.should.be.a('array');
+    res.body[0].should.have.a.property('name');
+    res.body[0].name.should.be.eql('unpair');
+
+    res.body[0].should.have.a.property('id');
+
+    res.body[0].should.have.a.property('status');
+    res.body[0].status.should.be.eql('error');
+
+    res.body[0].should.have.a.property('error');
+    done();
+  });
+});
+

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -3,22 +3,22 @@
 /* Tell jshint about mocha globals, and  */
 /* globals it */
 
-const {server, chai, mockAdapter, rp} = require('../common');
+const {server, chai, mockAdapter} = require('../common');
 
 var Constants = require('../../constants');
 const WebSocket = require('ws');
 
 it('removes all existing actions', done => {
 
-  rp(chai.request(server)
-    .get(Constants.ACTIONS_PATH)).then(res => {
+  chai.request(server)
+    .get(Constants.ACTIONS_PATH).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
 
     // Issue a request to delete all current actions
     let deleteReqs = res.body.map(action => {
-      return rp(chai.request(server)
-        .delete(Constants.ACTIONS_PATH + '/' + action.id));
+      return chai.request(server)
+        .delete(Constants.ACTIONS_PATH + '/' + action.id);
     });
 
     return Promise.all(deleteReqs);
@@ -27,8 +27,8 @@ it('removes all existing actions', done => {
       res.should.have.status(204);
     }
 
-    return rp(chai.request(server)
-      .get(Constants.ACTIONS_PATH));
+    return chai.request(server)
+      .get(Constants.ACTIONS_PATH);
   }).then(res => {
     res.body.should.be.a('array');
     res.body.length.should.be.eql(0);
@@ -85,8 +85,8 @@ it('should create a new pairing action', (done) => {
 });
 
 it('should list and retrieve the new action', (done) => {
-  rp(chai.request(server)
-    .get(Constants.ACTIONS_PATH)).then(res => {
+  chai.request(server)
+    .get(Constants.ACTIONS_PATH).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
     res.body.length.should.be.eql(1);
@@ -96,8 +96,8 @@ it('should list and retrieve the new action', (done) => {
 
     return res.body[0].id;
   }).then(actionId => {
-    return rp(chai.request(server)
-      .get(Constants.ACTIONS_PATH + '/' + actionId));
+    return chai.request(server)
+      .get(Constants.ACTIONS_PATH + '/' + actionId);
   }).then(res => {
     res.should.have.status(200);
     res.body.should.have.a.property('name');
@@ -110,8 +110,8 @@ it('should list and retrieve the new action', (done) => {
 
 it('should error retrieving a nonexistent action', (done) => {
   let actionId = 'tomato';
-  rp(chai.request(server)
-    .get(Constants.ACTIONS_PATH + '/' + actionId)).then(() => {
+  chai.request(server)
+    .get(Constants.ACTIONS_PATH + '/' + actionId).then(() => {
     throw new Error('Response should be 404');
   }).catch(err => {
     err.response.should.have.status(404);
@@ -121,21 +121,21 @@ it('should error retrieving a nonexistent action', (done) => {
 
 it('should remove an action', done => {
 
-  rp(chai.request(server)
-    .get(Constants.ACTIONS_PATH)).then(res => {
+  chai.request(server)
+    .get(Constants.ACTIONS_PATH).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
     res.body.length.should.be.eql(1);
     let actionId = res.body[0].id;
     return actionId;
   }).then(actionId => {
-    return rp(chai.request(server)
-      .delete(Constants.ACTIONS_PATH + '/' + actionId));
+    return chai.request(server)
+      .delete(Constants.ACTIONS_PATH + '/' + actionId);
   }).then(res => {
     res.should.have.status(204);
 
-    return rp(chai.request(server)
-      .get(Constants.ACTIONS_PATH));
+    return chai.request(server)
+      .get(Constants.ACTIONS_PATH);
   }).then(res => {
     res.body.should.be.a('array');
     res.body.length.should.be.eql(0);
@@ -147,8 +147,8 @@ it('should remove an action', done => {
 it('should error removing a nonexistent action', done => {
   let actionId = 555;
 
-  rp(chai.request(server)
-    .delete(Constants.ACTIONS_PATH + '/' + actionId)).then(res => {
+  chai.request(server)
+    .delete(Constants.ACTIONS_PATH + '/' + actionId).then(res => {
     throw new Error('Not a 404');
   }).catch(err => {
     err.response.status.should.be.eql(404);
@@ -163,12 +163,12 @@ it('should error on an unpair of a nonexistent device',
   // a specific device
   mockAdapter().unpairDevice(thingId);
 
-  rp(chai.request(server)
+  chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send({name: 'unpair', parameters: {id: thingId}})).then(res => {
+    .send({name: 'unpair', parameters: {id: thingId}}).then(res => {
     res.should.have.status(201);
-    return rp(chai.request(server)
-      .get(Constants.ACTIONS_PATH));
+    return chai.request(server)
+      .get(Constants.ACTIONS_PATH);
   }).then(res => {
     res.body.should.be.a('array');
     res.body[0].should.have.a.property('name');

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -119,7 +119,6 @@ it('should error retrieving a nonexistent action', (done) => {
   });
 });
 
-
 it('should remove an action', done => {
 
   rp(chai.request(server)
@@ -144,7 +143,6 @@ it('should remove an action', done => {
     done();
   });
 });
-
 
 it('should error removing a nonexistent action', done => {
   let actionId = 555;

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/* Tell jshint about mocha globals, and  */
+/* globals it */
+
+const {server, chai, mockAdapter, rp} = require('../common');
+
+var Constants = require('../../constants');
+const WebSocket = require('ws');
+
+
+it('GET with no actions', (done) => {
+  chai.request(server)
+    .get(Constants.ACTIONS_PATH)
+    .end((err, res) => {
+      console.log(res.body);
+      res.should.have.status(200);
+      res.body.should.be.a('array');
+      res.body.length.should.be.eql(0);
+      done();
+    });
+});
+
+it('should fail to create a new action (empty body)', (done) => {
+  chai.request(server)
+    .post(Constants.ACTIONS_PATH)
+    .send()
+    .end((err, res) => {
+      res.should.have.status(400);
+      done();
+    });
+});
+
+it('should fail to create a new action (unknown name)', (done) => {
+  let descr = {
+    name: 'potato'
+  };
+  chai.request(server)
+    .post(Constants.ACTIONS_PATH)
+    .send(descr)
+    .end((err, res) => {
+      res.should.have.status(400);
+      done();
+    });
+});
+
+it('should create a new pairing action', (done) => {
+  let descr = {
+    name: 'pair'
+  };
+  chai.request(server)
+    .post(Constants.ACTIONS_PATH)
+    .send(descr)
+    .end((err, res) => {
+      res.should.have.status(201);
+      done();
+    });
+});
+
+
+it('should retrieve the new action', (done) => {
+  chai.request(server)
+    .get(Constants.ACTIONS_PATH)
+    .end((err, res) => {
+      res.should.have.status(200);
+      res.body.should.be.a('array');
+      res.body.length.should.be.eql(1);
+      res.body[0].should.have.a.property('name');
+      res.body[0].should.have.a.property('id');
+      res.body[0].name.should.be.eql('pair');
+      done();
+    });
+});
+
+it('should remove an action', done => {
+
+  rp(chai.request(server)
+    .get(Constants.ACTIONS_PATH)).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+    res.body.length.should.be.eql(1);
+    let actionId = res.body[0].id;
+    return actionId;
+  }).then(actionId => {
+    return rp(chai.request(server)
+      .delete(Constants.ACTIONS_PATH + '/' + actionId));
+  }).then(res => {
+    res.should.have.status(204);
+
+    return rp(chai.request(server)
+      .get(Constants.ACTIONS_PATH));
+  }).then(res => {
+    res.body.should.be.a('array');
+    res.body.length.should.be.eql(0);
+
+    done();
+  });
+});
+

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -13,7 +13,6 @@ it('GET with no actions', (done) => {
   chai.request(server)
     .get(Constants.ACTIONS_PATH)
     .end((err, res) => {
-      console.log(res.body);
       res.should.have.status(200);
       res.body.should.be.a('array');
       res.body.length.should.be.eql(0);

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -56,20 +56,41 @@ it('should create a new pairing action', (done) => {
     });
 });
 
+it('should list and retrieve the new action', (done) => {
+  rp(chai.request(server)
+    .get(Constants.ACTIONS_PATH)).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+    res.body.length.should.be.eql(1);
+    res.body[0].should.have.a.property('name');
+    res.body[0].should.have.a.property('id');
+    res.body[0].name.should.be.eql('pair');
 
-it('should retrieve the new action', (done) => {
-  chai.request(server)
-    .get(Constants.ACTIONS_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.be.a('array');
-      res.body.length.should.be.eql(1);
-      res.body[0].should.have.a.property('name');
-      res.body[0].should.have.a.property('id');
-      res.body[0].name.should.be.eql('pair');
-      done();
-    });
+    return res.body[0].id;
+  }).then(actionId => {
+    return rp(chai.request(server)
+      .get(Constants.ACTIONS_PATH + '/' + actionId));
+  }).then(res => {
+    res.should.have.status(200);
+    res.body.should.have.a.property('name');
+    res.body.name.should.be.eql('pair');
+    res.body.should.have.a.property('id');
+
+    done();
+  });
 });
+
+it('should error retrieving a nonexistent action', (done) => {
+  let actionId = 'tomato';
+  rp(chai.request(server)
+    .get(Constants.ACTIONS_PATH + '/' + actionId)).then(() => {
+    throw new Error('Response should be 404');
+  }).catch(err => {
+    err.response.should.have.status(404);
+    done();
+  });
+});
+
 
 it('should remove an action', done => {
 

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -46,6 +46,7 @@ it('should fail to create a new action (empty body)', async () => {
     await chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .send();
+    throw new Error('request should fail');
   } catch(err) {
     err.response.should.have.status(400);
   }
@@ -59,6 +60,7 @@ it('should fail to create a new action (unknown name)', async () => {
     await chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .send(descr);
+    throw new Error('request should fail');
   } catch(err) {
     err.response.should.have.status(400);
   }
@@ -97,8 +99,9 @@ it('should list and retrieve the new action', async () => {
 it('should error retrieving a nonexistent action', async () => {
   let actionId = 'tomato';
   try {
-    const res = await chai.request(server)
+    await chai.request(server)
       .get(Constants.ACTIONS_PATH + '/' + actionId);
+    throw new Error('request should fail');
   } catch(err) {
     err.response.should.have.status(404);
   }
@@ -129,6 +132,7 @@ it('should error removing a nonexistent action', async () => {
   try {
     await chai.request(server)
       .delete(Constants.ACTIONS_PATH + '/' + actionId);
+    throw new Error('request should fail');
   } catch(err) {
     err.response.status.should.be.eql(404);
   }

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -97,6 +97,18 @@ it('should remove an action', done => {
 });
 
 
+it('should error removing a nonexistent action', done => {
+  let actionId = 555;
+
+  rp(chai.request(server)
+    .delete(Constants.ACTIONS_PATH + '/' + actionId)).then(res => {
+    throw new Error('Not a 404');
+  }).catch(err => {
+    err.response.status.should.be.eql(404);
+    done();
+  });
+});
+
 it('should error on an unpair of a nonexistent device',
    done => {
   let thingId = 'test-nonexistent';

--- a/test/integration/actions-test.js
+++ b/test/integration/actions-test.js
@@ -8,6 +8,34 @@ const {server, chai, mockAdapter, rp} = require('../common');
 var Constants = require('../../constants');
 const WebSocket = require('ws');
 
+it('removes all existing actions', done => {
+
+  rp(chai.request(server)
+    .get(Constants.ACTIONS_PATH)).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+
+    // Issue a request to delete all current actions
+    let deleteReqs = res.body.map(action => {
+      return rp(chai.request(server)
+        .delete(Constants.ACTIONS_PATH + '/' + action.id));
+    });
+
+    return Promise.all(deleteReqs);
+  }).then(responses => {
+    for (let res of responses) {
+      res.should.have.status(204);
+    }
+
+    return rp(chai.request(server)
+      .get(Constants.ACTIONS_PATH));
+  }).then(res => {
+    res.body.should.be.a('array');
+    res.body.length.should.be.eql(0);
+
+    done();
+  });
+});
 
 it('GET with no actions', (done) => {
   chai.request(server)

--- a/test/integration/adapters-test.js
+++ b/test/integration/adapters-test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/* Tell jshint about mocha globals, and  */
+/* globals it, chai, mockAdapter, server */
+
+require('../common');
+
+var Constants = require('../../constants');
+
+
+it('gets all adapters', (done) => {
+  rp(chai.request(server)
+    .get(Constants.ADAPTERS_PATH)).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+    res.body.length.should.be.eql(1);
+    res.body[0].should.have.a.property('id');
+    res.body[0].id.should.be.eql(mockAdapter().getId());
+    res.body[0].should.have.a.property('ready');
+    res.body[0].ready.should.be.eql(mockAdapter().isReady());
+    done();
+  });
+});
+
+it('gets specifically mockAdapter', (done) => {
+  let mockAdapterId = mockAdapter().getId();
+
+  rp(chai.request(server)
+    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId)).then(res => {
+    res.should.have.status(200);
+    res.body.should.have.a.property('id');
+    res.body.id.should.be.eql(mockAdapter().getId());
+    res.body.should.have.a.property('ready');
+    res.body.ready.should.be.eql(mockAdapter().isReady());
+
+    done();
+  });
+});
+

--- a/test/integration/adapters-test.js
+++ b/test/integration/adapters-test.js
@@ -9,44 +9,38 @@ var Constants = require('../../constants');
 
 
 
-it('gets all adapters', (done) => {
-  chai.request(server)
-    .get(Constants.ADAPTERS_PATH).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    res.body.length.should.be.eql(1);
-    res.body[0].should.have.a.property('id');
-    res.body[0].id.should.be.eql(mockAdapter().getId());
-    res.body[0].should.have.a.property('ready');
-    res.body[0].ready.should.be.eql(mockAdapter().isReady());
-    done();
-  });
+it('gets all adapters', async () => {
+  const res = await chai.request(server)
+    .get(Constants.ADAPTERS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(1);
+  res.body[0].should.have.a.property('id');
+  res.body[0].id.should.be.eql(mockAdapter().getId());
+  res.body[0].should.have.a.property('ready');
+  res.body[0].ready.should.be.eql(mockAdapter().isReady());
 });
 
-it('gets specifically mockAdapter', (done) => {
+it('gets specifically mockAdapter', async () => {
   let mockAdapterId = mockAdapter().getId();
 
-  chai.request(server)
-    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId).then(res => {
-    res.should.have.status(200);
-    res.body.should.have.a.property('id');
-    res.body.id.should.be.eql(mockAdapter().getId());
-    res.body.should.have.a.property('ready');
-    res.body.ready.should.be.eql(mockAdapter().isReady());
-
-    done();
-  });
+  const res = await chai.request(server)
+    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId);
+  res.should.have.status(200);
+  res.body.should.have.a.property('id');
+  res.body.id.should.be.eql(mockAdapter().getId());
+  res.body.should.have.a.property('ready');
+  res.body.ready.should.be.eql(mockAdapter().isReady());
 });
 
-it('fails to get a nonexistent adapter', (done) => {
+it('fails to get a nonexistent adapter', async () => {
   let mockAdapterId = 'nonexistent-adapter';
 
-  chai.request(server)
-    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId).then(() => {
-    throw new Error('Reponse should be a 404');
-  }).catch(err => {
+  try {
+    await chai.request(server)
+      .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId);
+  } catch(err) {
     err.response.should.have.status(404);
-    done();
-  });
+  }
 });
 

--- a/test/integration/adapters-test.js
+++ b/test/integration/adapters-test.js
@@ -10,8 +10,8 @@ var Constants = require('../../constants');
 
 
 it('gets all adapters', (done) => {
-  rp(chai.request(server)
-    .get(Constants.ADAPTERS_PATH)).then(res => {
+  chai.request(server)
+    .get(Constants.ADAPTERS_PATH).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
     res.body.length.should.be.eql(1);
@@ -26,8 +26,8 @@ it('gets all adapters', (done) => {
 it('gets specifically mockAdapter', (done) => {
   let mockAdapterId = mockAdapter().getId();
 
-  rp(chai.request(server)
-    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId)).then(res => {
+  chai.request(server)
+    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId).then(res => {
     res.should.have.status(200);
     res.body.should.have.a.property('id');
     res.body.id.should.be.eql(mockAdapter().getId());
@@ -41,8 +41,8 @@ it('gets specifically mockAdapter', (done) => {
 it('fails to get a nonexistent adapter', (done) => {
   let mockAdapterId = 'nonexistent-adapter';
 
-  rp(chai.request(server)
-    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId)).then(() => {
+  chai.request(server)
+    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId).then(() => {
     throw new Error('Reponse should be a 404');
   }).catch(err => {
     err.response.should.have.status(404);

--- a/test/integration/adapters-test.js
+++ b/test/integration/adapters-test.js
@@ -1,11 +1,12 @@
 'use strict';
 
 /* Tell jshint about mocha globals, and  */
-/* globals it, chai, mockAdapter, server */
+/* globals it */
 
-require('../common');
+const {server, chai, mockAdapter, rp} = require('../common');
 
 var Constants = require('../../constants');
+
 
 
 it('gets all adapters', (done) => {

--- a/test/integration/adapters-test.js
+++ b/test/integration/adapters-test.js
@@ -39,6 +39,7 @@ it('fails to get a nonexistent adapter', async () => {
   try {
     await chai.request(server)
       .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId);
+    throw new Error('request should fail');
   } catch(err) {
     err.response.should.have.status(404);
   }

--- a/test/integration/adapters-test.js
+++ b/test/integration/adapters-test.js
@@ -37,3 +37,15 @@ it('gets specifically mockAdapter', (done) => {
   });
 });
 
+it('fails to get a nonexistent adapter', (done) => {
+  let mockAdapterId = 'nonexistent-adapter';
+
+  rp(chai.request(server)
+    .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId)).then(() => {
+    throw new Error('Reponse should be a 404');
+  }).catch(err => {
+    err.response.should.have.status(404);
+    done();
+  });
+});
+

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -9,28 +9,26 @@ const assert = chai.assert;
 var Constants = require('../../constants');
 const WebSocket = require('ws');
 
-it('GET with no things', (done) => {
-  chai.request(server)
+it('GET with no things', async () => {
+  const res = await chai.request(server)
     .get(Constants.THINGS_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.be.a('array');
-      res.body.length.should.be.eql(0);
-      done();
-    });
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(0);
 });
 
-it('fail to create a new thing (empty body)', (done) => {
-  chai.request(server)
-    .post(Constants.THINGS_PATH)
-    .send()
-    .end((err, res) => {
-      res.should.have.status(400);
-      done();
-    });
+it('fail to create a new thing (empty body)', async () => {
+  try {
+    await chai.request(server)
+      .post(Constants.THINGS_PATH)
+      .send();
+    throw new Error('Should have failed to create new thing');
+  } catch(err) {
+    err.response.should.have.status(400);
+  }
 });
 
-it('create a new thing', (done) => {
+it('create a new thing', async () => {
   // Create the thing at the adapter level allows the property stuff
   // later to work. We're essentially creating a paired thing.
   let descr = {
@@ -42,121 +40,113 @@ it('create a new thing', (done) => {
     }
   };
   mockAdapter().addDevice('test-1', descr);
-  chai.request(server)
+  const res = await chai.request(server)
     .post(Constants.THINGS_PATH)
-    .send(descr)
-    .end((err, res) => {
-      res.should.have.status(201);
-      done();
-    });
+    .send(descr);
+  res.should.have.status(201);
 });
 
-it('fail to create a new thing (duplicate)', (done) => {
-  chai.request(server)
-    .post(Constants.THINGS_PATH)
-    .send({
-      id: 'test-1',
-    })
-    .end((err, res) => {
-      res.should.have.status(500);
-      done();
-    });
+it('fail to create a new thing (duplicate)', async () => {
+  try {
+    await chai.request(server)
+      .post(Constants.THINGS_PATH)
+      .send({
+        id: 'test-1',
+      });
+    throw new Error('Should have failed to create new thing');
+  } catch(err) {
+    err.response.should.have.status(500);
+  }
 });
 
-it('GET with 1 thing', (done) => {
-  chai.request(server)
-    .get(Constants.THINGS_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.be.a('array');
-      res.body.length.should.be.eql(1);
-      res.body[0].should.have.a.property('href');
-      res.body[0].href.should.be.eql(Constants.THINGS_PATH + '/test-1');
-      done();
-    });
+it('GET with 1 thing', async () => {
+  const res = await chai.request(server)
+    .get(Constants.THINGS_PATH);
+
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(1);
+  res.body[0].should.have.a.property('href');
+  res.body[0].href.should.be.eql(Constants.THINGS_PATH + '/test-1');
 });
 
-it('GET a property of a thing', (done) => {
-  chai.request(server)
-    .get(Constants.THINGS_PATH + '/test-1/properties/on')
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.have.a.property('on');
-      res.body.on.should.be.eql(false);
-      done();
-    });
+it('GET a property of a thing', async () => {
+  const res = await chai.request(server)
+    .get(Constants.THINGS_PATH + '/test-1/properties/on');
+
+  res.should.have.status(200);
+  res.body.should.have.a.property('on');
+  res.body.on.should.be.eql(false);
 });
 
-it('fail to GET a non-existant property of a thing', (done) => {
-  chai.request(server)
-    .get(Constants.THINGS_PATH + '/test-1/properties/xyz')
-    .end((err, res) => {
-      res.should.have.status(500);
-      done();
-    });
+it('fail to GET a non-existant property of a thing', async () => {
+  try {
+    await chai.request(server)
+      .get(Constants.THINGS_PATH + '/test-1/properties/xyz');
+    throw new Error('request should fail');
+  } catch(err) {
+    err.response.should.have.status(500);
+  }
 });
 
-it('fail to GET a property of a non-existent thing', (done) => {
-  chai.request(server)
-    .get(Constants.THINGS_PATH + '/test-1a/properties/on')
-    .end((err, res) => {
-      res.should.have.status(500);
-      done();
-    });
+it('fail to GET a property of a non-existent thing', async () => {
+  try {
+    await chai.request(server)
+      .get(Constants.THINGS_PATH + '/test-1a/properties/on');
+    throw new Error('request should fail');
+  } catch(err) {
+    err.response.should.have.status(500);
+  }
 });
 
-it('fail to set a property of a thing', (done) => {
-  chai.request(server)
+it('fail to set a property of a thing', async () => {
+  try {
+    await chai.request(server)
+      .put(Constants.THINGS_PATH + '/test-1/properties/on')
+      .send({});
+    throw new Error('request should fail');
+  } catch(err) {
+    err.response.should.have.status(400);
+  }
+});
+
+it('fail to set a property of a thing', async () => {
+  try {
+    await chai.request(server)
+      .put(Constants.THINGS_PATH + '/test-1/properties/on')
+      .send({abc: true});
+    throw new Error('request should fail');
+  } catch(err) {
+    err.response.should.have.status(400);
+  }
+});
+
+it('set a property of a thing', async () => {
+  const res = await chai.request(server)
     .put(Constants.THINGS_PATH + '/test-1/properties/on')
-    .send({})
-    .end((err, res) => {
-      res.should.have.status(400);
-      done();
-    });
+    .send({on: true});
+
+  res.should.have.status(200);
+  res.body.should.have.a.property('on');
+  res.body.on.should.be.eql(true);
 });
 
-it('fail to set a property of a thing', (done) => {
-  chai.request(server)
-    .put(Constants.THINGS_PATH + '/test-1/properties/on')
-    .send({abc: true})
-    .end((err, res) => {
-      res.should.have.status(400);
-      done();
-    });
+it('Verify property of a thing changed', async () => {
+  const res = await chai.request(server)
+    .get(Constants.THINGS_PATH + '/test-1/properties/on');
+
+  res.should.have.status(200);
+  res.body.should.have.a.property('on');
+  res.body.on.should.be.eql(true);
 });
 
-it('set a property of a thing', (done) => {
-  chai.request(server)
-    .put(Constants.THINGS_PATH + '/test-1/properties/on')
-    .send({on: true})
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.have.a.property('on');
-      res.body.on.should.be.eql(true);
-      done();
-    });
-});
+it('lists 0 new things after creating thing', async () => {
+  const res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH);
 
-it('Verify property of a thing changed', (done) => {
-  chai.request(server)
-    .get(Constants.THINGS_PATH + '/test-1/properties/on')
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.have.a.property('on');
-      res.body.on.should.be.eql(true);
-      done();
-    });
-});
-
-it('lists 0 new things after creating thing', (done) => {
-  chai.request(server)
-    .get(Constants.NEW_THINGS_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.be.a('array');
-      res.body.length.should.be.eql(0);
-      done();
-    });
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(0);
 });
 
 function makeDescr(id) {
@@ -167,25 +157,23 @@ function makeDescr(id) {
   };
 }
 
-it('lists new things when devices are added', (done) => {
+it('lists new things when devices are added', async () => {
   mockAdapter().addDevice('test-2', makeDescr('test-2'));
   mockAdapter().addDevice('test-3', makeDescr('test-3'));
 
-  chai.request(server)
-    .get(Constants.NEW_THINGS_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.should.be.a('array');
-      res.body.length.should.be.eql(2);
-      res.body[0].should.have.a.property('href');
-      res.body[0].href.should.be.eql(Constants.THINGS_PATH + '/test-2');
-      res.body[1].should.have.a.property('href');
-      res.body[1].href.should.be.eql(Constants.THINGS_PATH + '/test-3');
-      done();
-    });
+  const res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH);
+
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  res.body.length.should.be.eql(2);
+  res.body[0].should.have.a.property('href');
+  res.body[0].href.should.be.eql(Constants.THINGS_PATH + '/test-2');
+  res.body[1].should.have.a.property('href');
+  res.body[1].href.should.be.eql(Constants.THINGS_PATH + '/test-3');
 });
 
-it('should send multiple devices during pairing', (done) => {
+it('should send multiple devices during pairing', async () => {
   let addr = server.address();
   let socketPath = 'wss://127.0.0.1:' + addr.port + Constants.NEW_THINGS_PATH;
   function connectSocket() {
@@ -215,165 +203,137 @@ it('should send multiple devices during pairing', (done) => {
     return true;
   }
 
-  connectSocket().then(ws => {
-    ws.on('message', function onNewThing(newThingStr) {
-      let newThing = JSON.parse(newThingStr);
-      found[newThing.id] = true;
-      if (allFound()) {
-        ws.removeEventListener('message', onNewThing);
-        done();
-      }
-    });
+  const res = await chai.request(server)
+    .post(Constants.ACTIONS_PATH)
+    .send({name: 'pair'});
 
-    chai.request(server)
-      .post(Constants.ACTIONS_PATH)
-      .send({name: 'pair'})
-      .end((err, res) => {
-        res.should.have.status(201);
-        mockAdapter().addDevice('test-4', makeDescr('test-4'));
-        mockAdapter().addDevice('test-5', makeDescr('test-5'));
-      });
-  });
+  res.should.have.status(201);
+  mockAdapter().addDevice('test-4', makeDescr('test-4'));
+  mockAdapter().addDevice('test-5', makeDescr('test-5'));
 });
 
-it('should add a device during pairing then create a thing', done => {
+it('should add a device during pairing then create a thing', async () => {
   let thingId = 'test-6';
   let descr = makeDescr(thingId);
   mockAdapter().pairDevice(thingId, descr);
   // send pair action
-  chai.request(server)
+  let res = await chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send({name: 'pair'}).then(res => {
+    .send({name: 'pair'});
+  res.should.have.status(201);
 
-    res.should.have.status(201);
-    return chai.request(server)
-        .get(Constants.NEW_THINGS_PATH);
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
+  res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  let found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
     }
-    assert(found, 'should find thing in /new_things output');
+  }
+  assert(found, 'should find thing in /new_things output');
 
-    return chai.request(server)
-      .post(Constants.THINGS_PATH)
-      .send(descr);
-  }).then(res => {
-    res.should.have.status(201);
-    return chai.request(server)
-        .get(Constants.NEW_THINGS_PATH);
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
+  res = await chai.request(server)
+    .post(Constants.THINGS_PATH)
+    .send(descr);
+  res.should.have.status(201);
+
+  res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
     }
-    assert(!found, 'should find no longer thing in /new_things output:'
-      + JSON.stringify(res.body, null, 2));
+  }
+  assert(!found, 'should find no longer thing in /new_things output:'
+    + JSON.stringify(res.body, null, 2));
 
-    return chai.request(server)
-        .get(Constants.THINGS_PATH);
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
+  res = await chai.request(server)
+    .get(Constants.THINGS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
     }
-    assert(found, 'should find thing in /new_things output');
-
-    done();
-  });
+  }
+  assert(found, 'should find thing in /new_things output');
 });
 
-it('should remove a thing', done => {
+it('should remove a thing', async () => {
   let thingId = 'test-6';
 
-  chai.request(server)
-    .delete(Constants.THINGS_PATH + '/' + thingId).then(res => {
-    res.should.have.status(204);
-    return chai.request(server)
-      .get(Constants.THINGS_PATH);
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
-    }
-    assert(!found, 'should not find thing in /things output');
+  let res = await chai.request(server)
+    .delete(Constants.THINGS_PATH + '/' + thingId);
+  res.should.have.status(204);
 
-    return chai.request(server)
-        .get(Constants.NEW_THINGS_PATH);
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
+  res = await chai.request(server)
+    .get(Constants.THINGS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  let found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
     }
-    assert(found, 'should find thing in /new_things output');
+  }
+  assert(!found, 'should not find thing in /things output');
 
-    done();
-  });
+  res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
+    }
+  }
+  assert(found, 'should find thing in /new_things output');
 });
 
-it('should remove a device', done => {
+it('should remove a device', async () => {
   let thingId = 'test-6';
-  mockAdapter().removeDevice(thingId).then(() => {
-    return chai.request(server)
-      .get(Constants.NEW_THINGS_PATH)
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
-    }
-    assert(!found, 'should not find thing in /new_things output');
+  await mockAdapter().removeDevice(thingId);
 
-    done();
-  });
+  const res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH);
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  let found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
+    }
+  }
+  assert(!found, 'should not find thing in /new_things output');
 });
 
-it('should remove a device in response to unpair', done => {
+it('should remove a device in response to unpair', async () => {
   let thingId = 'test-5';
   // The mock adapter requires knowing in advance that we're going to unpair
   // a specific device
   mockAdapter().unpairDevice(thingId);
-  chai.request(server)
+  let res = await chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send({name: 'unpair', parameters: {id: thingId}}).then(res => {
-    res.should.have.status(201);
-    return chai.request(server)
-      .get(Constants.NEW_THINGS_PATH)
-  }).then(res => {
-    res.should.have.status(200);
-    res.body.should.be.a('array');
-    let found = false;
-    for (let thing of res.body) {
-      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
-        found = true;
-      }
+    .send({name: 'unpair', parameters: {id: thingId}});
+  res.should.have.status(201);
+
+  res = await chai.request(server)
+    .get(Constants.NEW_THINGS_PATH)
+  res.should.have.status(200);
+  res.body.should.be.a('array');
+  let found = false;
+  for (let thing of res.body) {
+    if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+      found = true;
     }
+  }
 
-    assert.isNotOk(found, 'should not find thing in /new_things output');
-
-    done();
-  });
+  assert.isNotOk(found, 'should not find thing in /new_things output');
 });

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -185,7 +185,7 @@ it('lists new things when devices are added', (done) => {
 });
 
 it('should send multiple devices during pairing', (done) => {
-  let addr = server._server.address();
+  let addr = server.address();
   let socketPath = 'wss://127.0.0.1:' + addr.port + Constants.NEW_THINGS_PATH;
   function connectSocket() {
     return new Promise((resolve, reject) => {

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -257,7 +257,7 @@ it('should add a device during pairing then create a thing', done => {
         found = true;
       }
     }
-    assert.isOk(found, 'should find thing in /new_things output');
+    assert(found, 'should find thing in /new_things output');
 
     return rp(chai.request(server)
       .post(Constants.THINGS_PATH)
@@ -275,7 +275,7 @@ it('should add a device during pairing then create a thing', done => {
         found = true;
       }
     }
-    assert.isNotOk(found, 'should find no longer thing in /new_things output:'
+    assert(!found, 'should find no longer thing in /new_things output:'
       + JSON.stringify(res.body, null, 2));
 
     return rp(chai.request(server)
@@ -289,7 +289,7 @@ it('should add a device during pairing then create a thing', done => {
         found = true;
       }
     }
-    assert.isOk(found, 'should find thing in /new_things output');
+    assert(found, 'should find thing in /new_things output');
 
     done();
   });
@@ -312,7 +312,40 @@ it('should remove a thing', done => {
         found = true;
       }
     }
-    assert.isNotOk(found, 'should not find thing in /things output');
+    assert(!found, 'should not find thing in /things output');
+
+    return rp(chai.request(server)
+        .get(Constants.NEW_THINGS_PATH));
+  }).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+    let found = false;
+    for (let thing of res.body) {
+      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+        found = true;
+      }
+    }
+    assert(found, 'should find thing in /new_things output');
+
+    done();
+  });
+});
+
+it('should remove a device', done => {
+  let thingId = 'test-6';
+  mockAdapter().removeDevice(thingId).then(() => {
+    return rp(chai.request(server)
+      .get(Constants.NEW_THINGS_PATH))
+  }).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+    let found = false;
+    for (let thing of res.body) {
+      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+        found = true;
+      }
+    }
+    assert(!found, 'should not find thing in /new_things output');
 
     done();
   });

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -241,13 +241,13 @@ it('should add a device during pairing then create a thing', done => {
   let descr = makeDescr(thingId);
   mockAdapter().pairDevice(thingId, descr);
   // send pair action
-  rp(chai.request(server)
+  chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send({name: 'pair'})).then(res => {
+    .send({name: 'pair'}).then(res => {
 
     res.should.have.status(201);
-    return rp(chai.request(server)
-        .get(Constants.NEW_THINGS_PATH));
+    return chai.request(server)
+        .get(Constants.NEW_THINGS_PATH);
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
@@ -259,13 +259,13 @@ it('should add a device during pairing then create a thing', done => {
     }
     assert(found, 'should find thing in /new_things output');
 
-    return rp(chai.request(server)
+    return chai.request(server)
       .post(Constants.THINGS_PATH)
-      .send(descr));
+      .send(descr);
   }).then(res => {
     res.should.have.status(201);
-    return rp(chai.request(server)
-        .get(Constants.NEW_THINGS_PATH));
+    return chai.request(server)
+        .get(Constants.NEW_THINGS_PATH);
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
@@ -278,8 +278,8 @@ it('should add a device during pairing then create a thing', done => {
     assert(!found, 'should find no longer thing in /new_things output:'
       + JSON.stringify(res.body, null, 2));
 
-    return rp(chai.request(server)
-        .get(Constants.THINGS_PATH));
+    return chai.request(server)
+        .get(Constants.THINGS_PATH);
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
@@ -298,11 +298,11 @@ it('should add a device during pairing then create a thing', done => {
 it('should remove a thing', done => {
   let thingId = 'test-6';
 
-  rp(chai.request(server)
-    .delete(Constants.THINGS_PATH + '/' + thingId)).then(res => {
+  chai.request(server)
+    .delete(Constants.THINGS_PATH + '/' + thingId).then(res => {
     res.should.have.status(204);
-    return rp(chai.request(server)
-      .get(Constants.THINGS_PATH));
+    return chai.request(server)
+      .get(Constants.THINGS_PATH);
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
@@ -314,8 +314,8 @@ it('should remove a thing', done => {
     }
     assert(!found, 'should not find thing in /things output');
 
-    return rp(chai.request(server)
-        .get(Constants.NEW_THINGS_PATH));
+    return chai.request(server)
+        .get(Constants.NEW_THINGS_PATH);
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
@@ -334,8 +334,8 @@ it('should remove a thing', done => {
 it('should remove a device', done => {
   let thingId = 'test-6';
   mockAdapter().removeDevice(thingId).then(() => {
-    return rp(chai.request(server)
-      .get(Constants.NEW_THINGS_PATH))
+    return chai.request(server)
+      .get(Constants.NEW_THINGS_PATH)
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');
@@ -356,12 +356,12 @@ it('should remove a device in response to unpair', done => {
   // The mock adapter requires knowing in advance that we're going to unpair
   // a specific device
   mockAdapter().unpairDevice(thingId);
-  rp(chai.request(server)
+  chai.request(server)
     .post(Constants.ACTIONS_PATH)
-    .send({name: 'unpair', parameters: {id: thingId}})).then(res => {
+    .send({name: 'unpair', parameters: {id: thingId}}).then(res => {
     res.should.have.status(201);
-    return rp(chai.request(server)
-      .get(Constants.NEW_THINGS_PATH))
+    return chai.request(server)
+      .get(Constants.NEW_THINGS_PATH)
   }).then(res => {
     res.should.have.status(200);
     res.body.should.be.a('array');

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -4,10 +4,10 @@
 /* globals it */
 
 const {server, chai, mockAdapter, rp} = require('../common');
+const assert = chai.assert;
 
 var Constants = require('../../constants');
 const WebSocket = require('ws');
-const assert = require('assert');
 
 it('GET with no things', (done) => {
   chai.request(server)

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -3,10 +3,11 @@
 /* Tell jshint about mocha globals, and  */
 /* globals it */
 
-const {server, chai, mockAdapter} = require('../common');
+const {server, chai, mockAdapter, rp} = require('../common');
 
 var Constants = require('../../constants');
 const WebSocket = require('ws');
+const assert = require('assert');
 
 it('GET with no things', (done) => {
   chai.request(server)
@@ -164,7 +165,7 @@ function makeDescr(id) {
     name: id,
     properties: {}
   };
-};
+}
 
 it('lists new things when devices are added', (done) => {
   mockAdapter().addDevice('test-2', makeDescr('test-2'));
@@ -235,18 +236,6 @@ it('should send multiple devices during pairing', (done) => {
   });
 });
 
-function rp(chaiRequest) {
-  return new Promise((resolve, reject) => {
-    chaiRequest.end((err, res) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(res);
-      }
-    });
-  });
-}
-
 it('should add a device during pairing then create a thing', done => {
   let thingId = 'test-6';
   let descr = makeDescr(thingId);
@@ -286,7 +275,8 @@ it('should add a device during pairing then create a thing', done => {
         found = true;
       }
     }
-    assert.isNotOk(found, 'should find no longer thing in /new_things output:' + JSON.stringify(res.body, null, 2));
+    assert.isNotOk(found, 'should find no longer thing in /new_things output:'
+      + JSON.stringify(res.body, null, 2));
 
     return rp(chai.request(server)
         .get(Constants.THINGS_PATH));

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -215,10 +215,11 @@ it('should send multiple devices during pairing', (done) => {
   }
 
   connectSocket().then(ws => {
-    ws.on('message', function(newThingStr) {
+    ws.on('message', function onNewThing(newThingStr) {
       let newThing = JSON.parse(newThingStr);
       found[newThing.id] = true;
       if (allFound()) {
+        ws.removeEventListener('message', onNewThing);
         done();
       }
     });

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -351,3 +351,29 @@ it('should remove a device', done => {
   });
 });
 
+it('should remove a device in response to unpair', done => {
+  let thingId = 'test-5';
+  // The mock adapter requires knowing in advance that we're going to unpair
+  // a specific device
+  mockAdapter().unpairDevice(thingId);
+  rp(chai.request(server)
+    .post(Constants.ACTIONS_PATH)
+    .send({name: 'unpair', parameters: {id: thingId}})).then(res => {
+    res.should.have.status(201);
+    return rp(chai.request(server)
+      .get(Constants.NEW_THINGS_PATH))
+  }).then(res => {
+    res.should.have.status(200);
+    res.body.should.be.a('array');
+    let found = false;
+    for (let thing of res.body) {
+      if (thing.href === Constants.THINGS_PATH + '/' + thingId) {
+        found = true;
+      }
+    }
+
+    assert.isNotOk(found, 'should not find thing in /new_things output');
+
+    done();
+  });
+});

--- a/test/integration/things-test.js
+++ b/test/integration/things-test.js
@@ -6,6 +6,7 @@
 const {server, chai, mockAdapter} = require('../common');
 
 var Constants = require('../../constants');
+const WebSocket = require('ws');
 
 it('GET with no things', (done) => {
   chai.request(server)
@@ -144,4 +145,91 @@ it('Verify property of a thing changed', (done) => {
       res.body.on.should.be.eql(true);
       done();
     });
+});
+
+it('lists 0 new things after creating thing', (done) => {
+  chai.request(server)
+    .get(Constants.NEW_THINGS_PATH)
+    .end((err, res) => {
+      res.should.have.status(200);
+      res.body.should.be.a('array');
+      res.body.length.should.be.eql(0);
+      done();
+    });
+});
+
+function makeDescr(id) {
+  return {
+    id: id,
+    name: id,
+    properties: {}
+  };
+};
+
+it('lists new things when devices are added', (done) => {
+  mockAdapter().addDevice('test-2', makeDescr('test-2'));
+  mockAdapter().addDevice('test-3', makeDescr('test-3'));
+
+  chai.request(server)
+    .get(Constants.NEW_THINGS_PATH)
+    .end((err, res) => {
+      res.should.have.status(200);
+      res.body.should.be.a('array');
+      res.body.length.should.be.eql(2);
+      res.body[0].should.have.a.property('href');
+      res.body[0].href.should.be.eql(Constants.THINGS_PATH + '/test-2');
+      res.body[1].should.have.a.property('href');
+      res.body[1].href.should.be.eql(Constants.THINGS_PATH + '/test-3');
+      done();
+    });
+});
+
+it('should send multiple devices during pairing', (done) => {
+  let addr = server._server.address();
+  let socketPath = 'wss://127.0.0.1:' + addr.port + Constants.NEW_THINGS_PATH;
+  function connectSocket() {
+    return new Promise((resolve, reject) => {
+      let ws = new WebSocket(socketPath);
+
+      ws.once('open', function() {
+        resolve(ws);
+      });
+    });
+  }
+
+  // We expect things test-2, test-3, test-4, and test-5 to show up eventually
+  let found = {
+    'test-2': false,
+    'test-3': false,
+    'test-4': false,
+    'test-5': false
+  };
+
+  function allFound() {
+    for (let id in found) {
+      if (!found[id]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  connectSocket().then(ws => {
+    ws.on('message', function(newThingStr) {
+      let newThing = JSON.parse(newThingStr);
+      found[newThing.id] = true;
+      if (allFound()) {
+        done();
+      }
+    });
+
+    chai.request(server)
+      .post(Constants.ACTIONS_PATH)
+      .send({name: 'pair'})
+      .end((err, res) => {
+        res.should.have.status(201);
+        mockAdapter().addDevice('test-4', makeDescr('test-4'));
+        mockAdapter().addDevice('test-5', makeDescr('test-5'));
+      });
+  });
 });

--- a/test/integration/users-test.js
+++ b/test/integration/users-test.js
@@ -14,76 +14,65 @@ const testUser = {
   password: 'rhubarb'
 };
 
-it('gets a route but is not authed', (done) => {
-  chai.request(server)
-    .get('/')
-    .end((err, res) => {
-      assert(res.request.url.endsWith('/login'),
-             'should be redirected to /login');
-      done();
-    });
+it('gets a route but is not authed', async () => {
+  const res = await chai.request(server)
+    .get('/');
+
+  assert(res.request.url.endsWith('/login'),
+         'should be redirected to /login');
 });
 
-it('creates a user', (done) => {
-  chai.request(server)
+it('creates a user', async () => {
+  const res = await chai.request(server)
     .post(Constants.USERS_PATH)
-    .send(testUser)
-    .end((err, res) => {
-      res.should.have.status(200);
-      done();
-    });
+    .send(testUser);
+
+  res.should.have.status(200);
 });
 
 
-it('fail to GET a non-existent user', (done) => {
-  chai.request(server)
-    .get(Constants.USERS_PATH + '/wrong@example.com')
-    .end((err, res) => {
-      res.should.have.status(404);
-      done();
-    });
+it('fail to GET a non-existent user', async () => {
+  try {
+    await chai.request(server)
+      .get(Constants.USERS_PATH + '/wrong@example.com');
+    throw new Error('request should fail');
+  } catch(err) {
+    err.response.should.have.status(404);
+  }
 });
 
-it('gets that user', (done) => {
-  chai.request(server)
-    .get(Constants.USERS_PATH + '/' + testUser.email)
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body.email.should.be.eql(testUser.email);
-      res.body.name.should.be.eql(testUser.name);
-      res.body.should.not.have.a.property('password');
+it('gets that user', async () => {
+  const res = await chai.request(server)
+    .get(Constants.USERS_PATH + '/' + testUser.email);
 
-      done();
-    });
+  res.should.have.status(200);
+  res.body.email.should.be.eql(testUser.email);
+  res.body.name.should.be.eql(testUser.name);
+  res.body.should.not.have.a.property('password');
+
 });
 
-it('logs out', (done) => {
-  chai.request(server)
-    .post(Constants.LOG_OUT_PATH)
-    .end((err, res) => {
-      res.should.have.status(200);
-      done();
-    });
+it('logs out', async () => {
+  const res = await chai.request(server)
+    .post(Constants.LOG_OUT_PATH);
+
+  res.should.have.status(200);
 });
 
-it('fails to create a user when a user exists', (done) => {
-  chai.request(server)
+it('fails to create a user when a user exists', async () => {
+  const res = await chai.request(server)
     .post(Constants.USERS_PATH)
-    .send(testUser)
-    .end((err, res) => {
-      assert.ok(res.request.url.endsWith('/login'),
-                'should be redirected to /login');
-      done();
-    });
+    .send(testUser);
+
+  assert.ok(res.request.url.endsWith('/login'),
+            'should be redirected to /login');
 });
 
-it('logs in as a user', (done) => {
-  chai.request(server)
+it('logs in as a user', async () => {
+  const res = await chai.request(server)
     .post(Constants.LOGIN_PATH)
-    .send(testUser)
-    .end((err, res) => {
-      res.should.have.status(200);
-      done();
-    });
+    .send(testUser);
+
+  res.should.have.status(200);
 });
 

--- a/test/integration/users-test.js
+++ b/test/integration/users-test.js
@@ -4,8 +4,8 @@
 /* globals it */
 
 const {chai, server} = require('../common');
+const assert = chai.assert;
 
-var assert = require('assert');
 var Constants = require('../../constants');
 
 const testUser = {
@@ -18,8 +18,8 @@ it('gets a route but is not authed', (done) => {
   chai.request(server)
     .get('/')
     .end((err, res) => {
-      assert.ok(res.request.url.endsWith('/login'),
-                'should be redirected to /login');
+      assert(res.request.url.endsWith('/login'),
+             'should be redirected to /login');
       done();
     });
 });


### PR DESCRIPTION
GitHub ate my last comment, so tl;dr:
- Switch tests to use the real https server instead of chai.request's http one
- Add more tests of ThingsController
- Create tests of ActionsController
- Change behavior of some parts of ActionsController
- Report coverage through `npm run cov` and `npm run cov-html`
- Incorporate #103