### PR TITLE
Add start script to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "mocha": "./test/run-tests.sh",
     "cov": "nyc npm run mocha",
-    "cov-html": "nyc --reporter=html npm run mocha"
+    "cov-html": "nyc --reporter=html npm run mocha",
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Many developers just expect `npm start` or `yarn start` to just work. This also lets us change the necessary start scripts in the future and `npm start` will always just work.