### PR TITLE
Verify and purge expired/deleted/revoked JWT

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -29,6 +29,18 @@
       }
     },
 
+    verifyJWT() {
+      const opts = {
+        headers: {
+          'Authorization': `Bearer ${window.API.jwt}`,
+        }
+      };
+
+      return fetch('/things/', opts).then((res) => {
+        return res.ok;
+      });
+    },
+
     createUser: function (name, email, password) {
       const opts = {
         method: 'POST',

--- a/static/js/check-user.js
+++ b/static/js/check-user.js
@@ -8,7 +8,17 @@
 'use strict';
 
 (function() {
-  if (!window.API.isLoggedIn()) {
+  if (window.API.isLoggedIn()) {
+    window.API.verifyJWT().then((valid) => {
+      if (!valid) {
+        redirectUnauthed();
+      }
+    });
+  } else {
+    redirectUnauthed();
+  }
+
+  function redirectUnauthed() {
     window.API.userCount().then((count) => {
       let url;
       if (count > 0) {


### PR DESCRIPTION
Sometimes a JWT becomes invalid due to database clobbering or other issues, but localStorage still has the invalid JWT. This correctly redirects to `/login` or `/signup` in this case.