### PR TITLE
Revert "Cache open-zwave-master directory"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ before_install:
   - npm install -g node-gyp
   - cd ..
 
-cache:
-  directories:
-    - open-zwave-master
-
 env:
   global:
     - CC=gcc-4.9


### PR DESCRIPTION
Reverts mozilla-iot/gateway#163

See https://travis-ci.org/mozilla-iot/gateway/builds/249783491?utm_source=github_status&utm_medium=notification . We need to do something different now that we have cache dir.