### PR TITLE
Update tunnel_setup.html path - fixes #222.

### DIFF
--- a/src/tunnel_setup.js
+++ b/src/tunnel_setup.js
@@ -37,7 +37,7 @@ var TunnelSetup = {
                 // if there are no certs installed,
                 // we display the cert setup page to the user
                 response.sendFile('tunnel_setup.html',
-                    { root: path.join(__dirname, 'views') });
+                    { root: path.join(__dirname, '../src/views') });
             }
         }
     }


### PR DESCRIPTION
This is a temporary fix to get first time setup working again.

This bug is caused because the build system assumes all HTML files are served from static/ and doesn't copy any HTML files across to the build/ directory. This patch just references the file in the src/ directory.

As part of wider work on our routing system I'm going to look at a better way of serving requests for HTML.