### PR TITLE
Thing Detail View

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /build/
 /coverage/
+/static/js/lib/

--- a/src/controllers/things_controller.js
+++ b/src/controllers/things_controller.js
@@ -48,6 +48,20 @@ ThingsController.post('/', function (request, response) {
 });
 
 /**
+ * Get a Thing.
+ */
+ ThingsController.get('/:thingId', function(request, response) {
+   var id = request.params.thingId;
+   Things.getThingDescription(id).then(function(thing) {
+     response.status(200).json(thing);
+   }).catch(function(error) {
+     console.error('Error getting thing description for thing with id ' + id);
+     console.error('Error: ' + error);
+     response.status(404).send(error);
+   });
+ });
+
+/**
  * Get a property of a Thing.
  */
 ThingsController.get('/:thingId/properties/:propertyName',

--- a/src/db.js
+++ b/src/db.js
@@ -147,6 +147,27 @@ var Database = {
   },
 
   /**
+   * Get a thing by its id.
+   *
+   * @param {string} id ID of the Thing to get.
+   */
+  getThing: function(id) {
+    return new Promise((function(resolve, reject) {
+      var db = this.db;
+      db.get('SELECT id, description FROM things WHERE id = ?', id,
+        function(error, row) {
+        if (error || row === undefined) {
+          reject(error);
+        } else {
+          var thing = JSON.parse(row.description);
+          thing.id = row.id;
+          resolve(thing);
+        }
+      });
+    }).bind(this));
+  },
+
+  /**
    * Add a new Thing to the Database.
    *
    * @param String id The ID to give the new Thing.

--- a/src/models/things.js
+++ b/src/models/things.js
@@ -128,6 +128,18 @@ var Things = {
    },
 
    /**
+    * Get a Thing description for a thing by its ID.
+    *
+    * @param {String} id The ID of the Thing to get a description of.
+    * @return {Object} A Thing description object.
+    */
+    getThingDescription: function(id) {
+      return Database.getThing(id).then((thing) => {
+        return new Thing(thing.id, thing).getDescription();
+      });
+    },
+
+   /**
     * Remove a Thing.
     *
     * @param String id ID to give Thing.

--- a/src/router.js
+++ b/src/router.js
@@ -24,30 +24,54 @@ var Router = {
    * Configure web app routes.
    */
   configure: function(app, opt) {
-    app.use('/', require('./controllers/root_controller'));
-    app.use(Constants.USERS_PATH, require('./controllers/users_controller'));
-    app.use(Constants.LOGIN_PATH, require('./controllers/login_controller'));
 
-    // These routes _must_ have authorization.
-    app.use(Constants.THINGS_PATH,
-      auth, require('./controllers/things_controller'));
-    app.use(Constants.NEW_THINGS_PATH,
-      auth, require('./controllers/new_things_controller'));
-    app.use(Constants.ADAPTERS_PATH,
-      auth, require('./controllers/adapters_controller'));
-    app.use(Constants.ACTIONS_PATH,
-      auth, require('./controllers/actions_controller'));
-    app.use(Constants.LOG_OUT_PATH,
-      auth, require('./controllers/log_out_controller'));
+    const API_PREFIX = '/api'; // A pseudo path to use for API requests
+    const APP_PREFIX = '/app'; // A pseudo path to use for front end requests
 
+    // First look for a static file
+    app.use(express.static(Constants.STATIC_PATH));
+
+    // Content negotiation middleware
+    app.use(function(request, response, next) {
+      // If request won't accept HTML but will accept JSON,
+      // or is a WebSocket request, treat it as an API request
+      if (!request.accepts('html') && request.accepts('json') ||
+          request.get('Upgrade') === 'websocket') {
+        request.url = API_PREFIX + request.url;
+        next();
+      // Otherwise treat it as an app request
+      } else {
+        request.url = APP_PREFIX + request.url;
+        next();
+      }
+    });
+
+    // Web app routes - send index.html and fall back to client side URL router
+    app.use(APP_PREFIX + '/*', require('./controllers/root_controller'));
+
+    // Unauthenticated API routes
+    app.use(API_PREFIX + Constants.LOGIN_PATH,
+      require('./controllers/login_controller'));
+    app.use(API_PREFIX + Constants.SETTINGS_PATH,
+      require('./controllers/tunnel_controller'));
     if (opt.options.debug) {
-      app.use(Constants.DEBUG_PATH, require('./controllers/debug_controller'));
+      app.use(API_PREFIX + Constants.DEBUG_PATH,
+      require('./controllers/debug_controller'));
     }
 
-    // XXX: This will go away eventually when gateway is purely an API server.
-    app.use(express.static(Constants.STATIC_PATH));
-    app.use(Constants.SETTINGS_PATH,
-        require('./controllers/tunnel_controller'));
+    // Authenticated API routes
+    app.use(API_PREFIX + Constants.THINGS_PATH,
+      auth, require('./controllers/things_controller'));
+    app.use(API_PREFIX + Constants.NEW_THINGS_PATH,
+      auth, require('./controllers/new_things_controller'));
+    app.use(API_PREFIX + Constants.ADAPTERS_PATH,
+      auth, require('./controllers/adapters_controller'));
+    app.use(API_PREFIX + Constants.ACTIONS_PATH,
+      auth, require('./controllers/actions_controller'));
+    app.use(API_PREFIX + Constants.LOG_OUT_PATH,
+      auth, require('./controllers/log_out_controller'));
+    app.use(API_PREFIX + Constants.USERS_PATH,
+      require('./controllers/users_controller'));
   }
 };
 

--- a/src/test/integration/actions-test.js
+++ b/src/test/integration/actions-test.js
@@ -24,6 +24,7 @@ describe('actions/', function() {
   it('GET with no actions', async () => {
     const res = await chai.request(server)
       .get(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -34,6 +35,7 @@ describe('actions/', function() {
     const err = await pFinal(chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .set(...headerAuth(jwt))
+      .set('Accept', 'application/json')
       .send());
     expect(err.response.status).toEqual(400);
   });
@@ -45,6 +47,7 @@ describe('actions/', function() {
     const err = await pFinal(chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .set(...headerAuth(jwt))
+      .set('Accept', 'application/json')
       .send(descr));
     expect(err.response.status).toEqual(400);
   });
@@ -57,12 +60,14 @@ describe('actions/', function() {
     const pair = await chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .set(...headerAuth(jwt))
+      .set('Accept', 'application/json')
       .send(descr);
 
     expect(pair.status).toEqual(201);
 
     let res = await chai.request(server)
       .get(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -74,6 +79,7 @@ describe('actions/', function() {
     const actionId = res.body[0].id;
     res = await chai.request(server)
       .get(Constants.ACTIONS_PATH + '/' + actionId)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty('name');
@@ -85,6 +91,7 @@ describe('actions/', function() {
     const actionId = 'foobarmissing';
     const err = await pFinal(chai.request(server)
       .get(Constants.ACTIONS_PATH + '/' + actionId)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt)));
     expect(err.response.status).toEqual(404);
   });
@@ -96,11 +103,13 @@ describe('actions/', function() {
 
     await chai.request(server)
       .post(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send(descr);
 
     let res = await chai.request(server)
       .get(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -109,11 +118,13 @@ describe('actions/', function() {
 
     res = await chai.request(server)
       .delete(Constants.ACTIONS_PATH + '/' + actionId)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(204);
 
     res = await chai.request(server)
       .get(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(Array.isArray(res.body)).toBeTruthy();
     expect(res.body.length).toEqual(0);
@@ -123,6 +134,7 @@ describe('actions/', function() {
     let actionId = 555;
     const err = await pFinal(chai.request(server)
       .delete(Constants.ACTIONS_PATH + '/' + actionId)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt)));
     expect(err.response.status).toEqual(404);
   });
@@ -136,11 +148,13 @@ describe('actions/', function() {
     let res = await chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .set(...headerAuth(jwt))
+      .set('Accept', 'application/json')
       .send({name: 'unpair', parameters: {id: thingId}});
     expect(res.status).toEqual(201);
 
     res = await chai.request(server)
         .get(Constants.ACTIONS_PATH)
+        .set('Accept', 'application/json')
         .set(...headerAuth(jwt));
     expect(Array.isArray(res.body)).toBeTruthy();
     expect(res.body[0]).toHaveProperty('name');

--- a/src/test/integration/adapters-test.js
+++ b/src/test/integration/adapters-test.js
@@ -12,7 +12,7 @@ const {
 
 const Constants = require('../../constants');
 
-describe('adapters', function() {
+describe('adapters/', function() {
   let jwt;
   beforeEach(async () => {
     jwt = await createUser(server, TEST_USER);
@@ -21,6 +21,7 @@ describe('adapters', function() {
   it('gets all adapters', async () => {
     const res = await chai.request(server)
       .get(Constants.ADAPTERS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -36,6 +37,7 @@ describe('adapters', function() {
 
     const res = await chai.request(server)
       .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(res.body).toHaveProperty('id');
@@ -50,6 +52,7 @@ describe('adapters', function() {
     try {
       await chai.request(server)
         .get(Constants.ADAPTERS_PATH + '/' + mockAdapterId)
+        .set('Accept', 'application/json')
         .set(...headerAuth(jwt));
       throw new Error('request should fail');
     } catch(err) {

--- a/src/test/integration/things-test.js
+++ b/src/test/integration/things-test.js
@@ -25,7 +25,7 @@ const TEST_THING = {
   }
 };
 
-describe('actions/', function() {
+describe('things/', function() {
   let jwt, toClose = [];
   beforeEach(async () => {
     jwt = await createUser(server, TEST_USER);
@@ -67,6 +67,7 @@ describe('actions/', function() {
     const {id} = desc;
     const res = await chai.request(server)
       .post(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send(TEST_THING);
     mockAdapter().addDevice(id, TEST_THING);
@@ -84,6 +85,7 @@ describe('actions/', function() {
   it('GET with no things', async () => {
     const res = await chai.request(server)
       .get(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -95,6 +97,7 @@ describe('actions/', function() {
       await chai.request(server)
         .post(Constants.THINGS_PATH)
         .set(...headerAuth(jwt))
+        .set('Accept', 'application/json')
         .send();
       throw new Error('Should have failed to create new thing');
     } catch(err) {
@@ -112,6 +115,7 @@ describe('actions/', function() {
     await addDevice();
     const res = await chai.request(server)
       .get(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
 
     expect(res.status).toEqual(200);
@@ -121,10 +125,33 @@ describe('actions/', function() {
     expect(res.body[0].href).toEqual(Constants.THINGS_PATH + '/test-1');
   });
 
+  it('GET a thing', async () => {
+    await addDevice();
+    const res = await chai.request(server)
+      .get(Constants.THINGS_PATH + '/test-1')
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.name).toEqual('test-1');
+  });
+
+  it('fail to GET a non-existent thing', async () => {
+    await addDevice();
+    const err = await pFinal(chai.request(server)
+      .get(Constants.THINGS_PATH + '/test-2')
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt)));
+
+    expect(err.response.status).toEqual(404);
+  });
+
   it('GET a property of a thing', async () => {
     await addDevice();
     const res = await chai.request(server)
       .get(Constants.THINGS_PATH + '/test-1/properties/on')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
 
     expect(res.status).toEqual(200);
@@ -135,6 +162,7 @@ describe('actions/', function() {
   it('fail to GET a non-existant property of a thing', async () => {
     const err = await pFinal(chai.request(server)
       .get(Constants.THINGS_PATH + '/test-1/properties/xyz')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt)));
 
     expect(err.response.status).toEqual(500);
@@ -143,6 +171,7 @@ describe('actions/', function() {
   it('fail to GET a property of a non-existent thing', async () => {
     const err = await pFinal(chai.request(server)
       .get(Constants.THINGS_PATH + '/test-1a/properties/on')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt)));
     expect(err.response.status).toEqual(500);
   });
@@ -151,6 +180,7 @@ describe('actions/', function() {
     await addDevice();
     const err = await pFinal(chai.request(server)
       .put(Constants.THINGS_PATH + '/test-1/properties/on')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send({}));
     expect(err.response.status).toEqual(400);
@@ -159,6 +189,7 @@ describe('actions/', function() {
   it('fail to set a property of a thing', async () => {
     const err = await pFinal(chai.request(server)
       .put(Constants.THINGS_PATH + '/test-1/properties/on')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send({abc: true}));
     expect(err.response.status).toEqual(400);
@@ -168,6 +199,7 @@ describe('actions/', function() {
     await addDevice();
     const on = await chai.request(server)
       .put(Constants.THINGS_PATH + '/test-1/properties/on')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send({on: true});
 
@@ -179,6 +211,7 @@ describe('actions/', function() {
     // Flip it back to off...
     const off = await chai.request(server)
       .put(Constants.THINGS_PATH + '/test-1/properties/on')
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send({on: false});
 
@@ -191,6 +224,7 @@ describe('actions/', function() {
     await addDevice();
     const res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
 
     expect(res.status).toEqual(200);
@@ -204,6 +238,7 @@ describe('actions/', function() {
 
     const res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
 
     expect(res.status).toEqual(200);
@@ -234,6 +269,7 @@ describe('actions/', function() {
       (async () => {
         const res = await chai.request(server)
           .post(Constants.ACTIONS_PATH)
+          .set('Accept', 'application/json')
           .set(...headerAuth(jwt))
           .send({name: 'pair'});
 
@@ -255,11 +291,13 @@ describe('actions/', function() {
     let res = await chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .set(...headerAuth(jwt))
+      .set('Accept', 'application/json')
       .send({name: 'pair'});
     expect(res.status).toEqual(201);
 
     res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -273,12 +311,14 @@ describe('actions/', function() {
 
     res = await chai.request(server)
       .post(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send(descr);
     expect(res.status).toEqual(201);
 
     res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -293,6 +333,7 @@ describe('actions/', function() {
 
     res = await chai.request(server)
       .get(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -313,16 +354,19 @@ describe('actions/', function() {
     let pair = await chai.request(server)
       .post(Constants.ACTIONS_PATH)
       .set(...headerAuth(jwt))
+      .set('Accept', 'application/json')
       .send({name: 'pair'});
     expect(pair.status).toEqual(201);
 
     let res = await chai.request(server)
       .delete(Constants.THINGS_PATH + '/' + thingId)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(204);
 
     res = await chai.request(server)
       .get(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -336,6 +380,7 @@ describe('actions/', function() {
 
     res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -358,6 +403,7 @@ describe('actions/', function() {
     // send pair action
     let pair = await chai.request(server)
       .post(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send({name: 'pair'});
     expect(pair.status).toEqual(201);
@@ -365,6 +411,7 @@ describe('actions/', function() {
 
     const res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -385,12 +432,14 @@ describe('actions/', function() {
     mockAdapter().unpairDevice(thingId);
     let res = await chai.request(server)
       .post(Constants.ACTIONS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
       .send({name: 'unpair', parameters: {id: thingId}});
     expect(res.status).toEqual(201);
 
     res = await chai.request(server)
       .get(Constants.NEW_THINGS_PATH)
+      .set('Accept', 'application/json')
       .set(...headerAuth(jwt));
     expect(res.status).toEqual(200);
     expect(Array.isArray(res.body)).toBeTruthy();
@@ -412,6 +461,7 @@ describe('actions/', function() {
         await addDevice();
         return await chai.request(server)
           .put(Constants.THINGS_PATH + '/' + TEST_THING.id + '/properties/on')
+          .set('Accept', 'application/json')
           .set(...headerAuth(jwt))
           .send({on: true});
       })(),

--- a/src/test/user.js
+++ b/src/test/user.js
@@ -20,6 +20,7 @@ const TEST_USER_DIFFERENT = {
 async function getJWT(path, server, user) {
   const res = await chai.request(server).
     post(path).
+    set('Accept', 'application/json').
     send(user);
   expect(res.status).toEqual(200);
   expect(typeof res.body.jwt).toBe('string');
@@ -38,6 +39,7 @@ async function userInfo(server, jwt) {
   const res = await chai.request(server).
     get(Constants.USERS_PATH + '/info').
     set(...headerAuth(jwt)).
+    set('Accept', 'application/json').
     send();
   expect(res.status).toEqual(200);
   expect(typeof res.body).toBe('object');
@@ -48,6 +50,7 @@ async function logoutUser(server, jwt) {
   const res = await chai.request(server).
     post(Constants.LOG_OUT_PATH).
     set(...headerAuth(jwt)).
+    set('Accept', 'application/json').
     send();
   expect(res.status).toEqual(200);
   return res;

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -41,15 +41,15 @@
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-#main-menu a[data-view='things'] {
+#main-menu #things-menu-item {
   background-image: url('../images/things-icon.png');
 }
 
-#main-menu a[data-view='adapters'] {
+#main-menu #adapters-menu-item {
   background-image: url('../images/adapters-icon.png');
 }
 
-#main-menu a[data-view='settings'] {
+#main-menu #settings-menu-item {
   background-image: url('../images/settings-icon.png');
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -7,44 +7,38 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Things Gateway</title>
-    <link rel="manifest" href="app.webmanifest">
-    <link rel="icon" href="images/icon.png" type="image/png" />
-    <!-- App -->
-    <script type="text/javascript" src="js/api.js"></script>
-    <script type="text/javascript" src="js/app.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/app.css" />
-    <!-- Things Screen -->
-    <script type="text/javascript" src="js/things.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/things.css" />
-    <!-- Adapters Screen -->
-    <script type="text/javascript" src="js/adapters.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/adapters.css" />
-    <!-- Menu -->
-    <script type="text/javascript" src="js/menu.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/menu.css" />
-    <!-- Add Thing -->
-    <script type="text/javascript" src="js/add-thing.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/add-thing.css" />
-    <!-- Context Menu -->
-    <script type="text/javascript" src="js/context-menu.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/context-menu.css" />
-    <!-- Thing -->
-    <script type="text/javascript" src="js/thing.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/thing.css" />
-    <!-- On/Off Switch -->
-    <script type="text/javascript" src="js/on-off-switch.js"></script>
-    <!-- New Thing -->
-    <script type="text/javascript" src="js/new-thing.js"></script>
-    <!-- Adapter -->
-    <script type="text/javascript" src="js/adapter.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/adapter.css" />
-    <script type="text/javascript" src="js/check-user.js"></script>
-    <!-- Settings -->
-    <script type="text/javascript" src="js/settings.js"></script>
-    <link rel="stylesheet" type="text/css" href="css/settings.css" />
+    <link rel="manifest" href="/app.webmanifest">
+    <link rel="icon" href="/images/icon.png" type="image/png" />
+
+    <link rel="stylesheet" type="text/css" href="/css/app.css" />
+    <link rel="stylesheet" type="text/css" href="/css/things.css" />
+    <link rel="stylesheet" type="text/css" href="/css/adapters.css" />
+    <link rel="stylesheet" type="text/css" href="/css/menu.css" />
+    <link rel="stylesheet" type="text/css" href="/css/add-thing.css" />
+    <link rel="stylesheet" type="text/css" href="/css/context-menu.css" />
+    <link rel="stylesheet" type="text/css" href="/css/thing.css" />
+    <link rel="stylesheet" type="text/css" href="/css/adapter.css" />
+    <link rel="stylesheet" type="text/css" href="/css/settings.css" />
+
+    <script type="text/javascript" src="/js/api.js"></script>
+    <script type="text/javascript" src="/js/app.js"></script>
+    <script type="text/javascript" src="/js/lib/page.js"></script>
+    <script type="text/javascript" src="/js/router.js"></script>
+    <script type="text/javascript" src="/js/things.js"></script>
+    <script type="text/javascript" src="/js/adapters.js"></script>
+    <script type="text/javascript" src="/js/menu.js"></script>
+    <script type="text/javascript" src="/js/add-thing.js"></script>
+    <script type="text/javascript" src="/js/context-menu.js"></script>
+    <script type="text/javascript" src="/js/thing.js"></script>
+    <script type="text/javascript" src="/js/on-off-switch.js"></script>
+    <script type="text/javascript" src="/js/new-thing.js"></script>
+    <script type="text/javascript" src="/js/adapter.js"></script>
+    <script type="text/javascript" src="/js/check-user.js"></script>
+    <script type="text/javascript" src="/js/settings.js"></script>
+
   </head>
   <body>
-    <img id="wordmark" src="images/moziot-wordmark.png" />
+    <img id="wordmark" src="/images/moziot-wordmark.png" />
 
     <!-- Things View -->
     <section data-view="things" class="selected" id="things-view">
@@ -69,9 +63,9 @@
     <!-- Menu -->
     <nav id="main-menu" class="hidden">
       <ul>
-        <li><a id="things-menu-item" data-view="things" href="" class="selected">Things</a></li>
-        <li><a id="adapters-menu-item" data-view="adapters" href="">Adapters</a></li>
-        <li><a id="settings-menu-item" data-view="settings" href="">Settings</a></li>
+        <li><a id="things-menu-item" data-view="things" href="/things" class="selected">Things</a></li>
+        <li><a id="adapters-menu-item" data-view="adapters" href="/adapters">Adapters</a></li>
+        <li><a id="settings-menu-item" data-view="settings" href="/settings">Settings</a></li>
         <li>
           <form id="logout" class="log-out-form">
             <button type="submit" class="log-out-button">Log out</button>
@@ -88,7 +82,7 @@
       <button id="add-thing-back-button" class="back-button"></button>
       <div id="add-thing-content">
         <p id="add-thing-status">
-          <img class="spinner" src="images/loading.gif" />Scanning for new devices...
+          <img class="spinner" src="/images/loading.gif" />Scanning for new devices...
         </p>
         <div id="new-things"></div>
         <button id="add-thing-cancel-button">Done</button>

--- a/static/index.html
+++ b/static/index.html
@@ -63,9 +63,9 @@
     <!-- Menu -->
     <nav id="main-menu" class="hidden">
       <ul>
-        <li><a id="things-menu-item" data-view="things" href="/things" class="selected">Things</a></li>
-        <li><a id="adapters-menu-item" data-view="adapters" href="/adapters">Adapters</a></li>
-        <li><a id="settings-menu-item" data-view="settings" href="/settings">Settings</a></li>
+        <li><a id="things-menu-item" href="/things" class="selected">Things</a></li>
+        <li><a id="adapters-menu-item" href="/adapters">Adapters</a></li>
+        <li><a id="settings-menu-item" href="/settings">Settings</a></li>
         <li>
           <form id="logout" class="log-out-form">
             <button type="submit" class="log-out-button">Log out</button>

--- a/static/js/adapters.js
+++ b/static/js/adapters.js
@@ -27,7 +27,8 @@ var AdaptersScreen = {
   showAdapters: function() {
     var opts = {
       headers: {
-        'Authorization': `Bearer ${window.API.jwt}`
+        'Authorization': `Bearer ${window.API.jwt}`,
+        'Accept': 'application/json'
       }
     };
     // Fetch a list of adapters from the server

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -16,7 +16,12 @@
     },
 
     userCount() {
-      return fetch('/users/count').then((res) => {
+      const opts = {
+        headers: {
+          'Accept': 'application/json'
+        }
+      };
+      return fetch('/users/count', opts).then((res) => {
         return res.json();
       }).then((body) => {
         return body.count;
@@ -33,6 +38,7 @@
       const opts = {
         headers: {
           'Authorization': `Bearer ${window.API.jwt}`,
+          'Accept': 'application/json'
         }
       };
 
@@ -45,7 +51,8 @@
       const opts = {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
         },
         body: JSON.stringify({
           name, email, password
@@ -67,7 +74,8 @@
       const opts = {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
         },
         body: JSON.stringify({
           email, password
@@ -92,7 +100,8 @@
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${window.API.jwt}`,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
         }
       }).then((res) => {
         if (res.status !== 200) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -40,8 +40,8 @@ var App = {
     this.menuButton.addEventListener('click', Menu.toggle.bind(Menu));
   },
 
-  showThings: function() {
-    ThingsScreen.init();
+  showThings: function(context) {
+    ThingsScreen.init(context.params.thingId || null);
     this.selectView('things');
   },
 
@@ -62,6 +62,7 @@ var App = {
     }
     this.views[this.currentView].classList.remove('selected');
     this.views[view].classList.add('selected');
+    Menu.selectItem(view);
     this.currentView = view;
   }
 };

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -10,7 +10,7 @@
 'use strict';
 
 /* globals ThingsScreen, AdaptersScreen,
-AddThingScreen, Menu, ContextMenu, SettingsScreen */
+AddThingScreen, Menu, ContextMenu, SettingsScreen, Router */
 
 var App = {
   /**
@@ -27,19 +27,32 @@ var App = {
    * Start Things Gateway app.
    */
   init: function() {
-    ThingsScreen.init();
-    AdaptersScreen.init();
     AddThingScreen.init();
     ContextMenu.init();
-    SettingsScreen.init();
     this.views = [];
     this.views.things = document.getElementById('things-view');
     this.views.adapters = document.getElementById('adapters-view');
     this.views.settings = document.getElementById('settings-view');
     this.currentView = 'things';
     Menu.init();
+    Router.init();
     this.menuButton = document.getElementById('menu-button');
     this.menuButton.addEventListener('click', Menu.toggle.bind(Menu));
+  },
+
+  showThings: function() {
+    ThingsScreen.init();
+    this.selectView('things');
+  },
+
+  showAdapters: function() {
+    AdaptersScreen.init();
+    this.selectView('adapters');
+  },
+
+  showSettings: function() {
+    SettingsScreen.init();
+    this.selectView('settings');
   },
 
   selectView: function(view) {

--- a/static/js/lib/page.js
+++ b/static/js/lib/page.js
@@ -1,0 +1,1127 @@
+/*
+Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+
+https://visionmedia.github.io/page.js/
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.page=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function (process){
+  /* globals require, module */
+
+  'use strict';
+
+  /**
+   * Module dependencies.
+   */
+
+  var pathtoRegexp = require('path-to-regexp');
+
+  /**
+   * Module exports.
+   */
+
+  module.exports = page;
+
+  /**
+   * Detect click event
+   */
+  var clickEvent = ('undefined' !== typeof document) && document.ontouchstart ? 'touchstart' : 'click';
+
+  /**
+   * To work properly with the URL
+   * history.location generated polyfill in https://github.com/devote/HTML5-History-API
+   */
+
+  var location = ('undefined' !== typeof window) && (window.history.location || window.location);
+
+  /**
+   * Perform initial dispatch.
+   */
+
+  var dispatch = true;
+
+
+  /**
+   * Decode URL components (query string, pathname, hash).
+   * Accommodates both regular percent encoding and x-www-form-urlencoded format.
+   */
+  var decodeURLComponents = true;
+
+  /**
+   * Base path.
+   */
+
+  var base = '';
+
+  /**
+   * Running flag.
+   */
+
+  var running;
+
+  /**
+   * HashBang option
+   */
+
+  var hashbang = false;
+
+  /**
+   * Previous context, for capturing
+   * page exit events.
+   */
+
+  var prevContext;
+
+  /**
+   * Register `path` with callback `fn()`,
+   * or route `path`, or redirection,
+   * or `page.start()`.
+   *
+   *   page(fn);
+   *   page('*', fn);
+   *   page('/user/:id', load, user);
+   *   page('/user/' + user.id, { some: 'thing' });
+   *   page('/user/' + user.id);
+   *   page('/from', '/to')
+   *   page();
+   *
+   * @param {string|!Function|!Object} path
+   * @param {Function=} fn
+   * @api public
+   */
+
+  function page(path, fn) {
+    // <callback>
+    if ('function' === typeof path) {
+      return page('*', path);
+    }
+
+    // route <path> to <callback ...>
+    if ('function' === typeof fn) {
+      var route = new Route(/** @type {string} */ (path));
+      for (var i = 1; i < arguments.length; ++i) {
+        page.callbacks.push(route.middleware(arguments[i]));
+      }
+      // show <path> with [state]
+    } else if ('string' === typeof path) {
+      page['string' === typeof fn ? 'redirect' : 'show'](path, fn);
+      // start [options]
+    } else {
+      page.start(path);
+    }
+  }
+
+  /**
+   * Callback functions.
+   */
+
+  page.callbacks = [];
+  page.exits = [];
+
+  /**
+   * Current path being processed
+   * @type {string}
+   */
+  page.current = '';
+
+  /**
+   * Number of pages navigated to.
+   * @type {number}
+   *
+   *     page.len == 0;
+   *     page('/login');
+   *     page.len == 1;
+   */
+
+  page.len = 0;
+
+  /**
+   * Get or set basepath to `path`.
+   *
+   * @param {string} path
+   * @api public
+   */
+
+  page.base = function(path) {
+    if (0 === arguments.length) return base;
+    base = path;
+  };
+
+  /**
+   * Bind with the given `options`.
+   *
+   * Options:
+   *
+   *    - `click` bind to click events [true]
+   *    - `popstate` bind to popstate [true]
+   *    - `dispatch` perform initial dispatch [true]
+   *
+   * @param {Object} options
+   * @api public
+   */
+
+  page.start = function(options) {
+    options = options || {};
+    if (running) return;
+    running = true;
+    if (false === options.dispatch) dispatch = false;
+    if (false === options.decodeURLComponents) decodeURLComponents = false;
+    if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
+    if (false !== options.click) {
+      document.addEventListener(clickEvent, onclick, false);
+    }
+    if (true === options.hashbang) hashbang = true;
+    if (!dispatch) return;
+    var url = (hashbang && ~location.hash.indexOf('#!')) ? location.hash.substr(2) + location.search : location.pathname + location.search + location.hash;
+    page.replace(url, null, true, dispatch);
+  };
+
+  /**
+   * Unbind click and popstate event handlers.
+   *
+   * @api public
+   */
+
+  page.stop = function() {
+    if (!running) return;
+    page.current = '';
+    page.len = 0;
+    running = false;
+    document.removeEventListener(clickEvent, onclick, false);
+    window.removeEventListener('popstate', onpopstate, false);
+  };
+
+  /**
+   * Show `path` with optional `state` object.
+   *
+   * @param {string} path
+   * @param {Object=} state
+   * @param {boolean=} dispatch
+   * @param {boolean=} push
+   * @return {!Context}
+   * @api public
+   */
+
+  page.show = function(path, state, dispatch, push) {
+    var ctx = new Context(path, state);
+    page.current = ctx.path;
+    if (false !== dispatch) page.dispatch(ctx);
+    if (false !== ctx.handled && false !== push) ctx.pushState();
+    return ctx;
+  };
+
+  /**
+   * Goes back in the history
+   * Back should always let the current route push state and then go back.
+   *
+   * @param {string} path - fallback path to go back if no more history exists, if undefined defaults to page.base
+   * @param {Object=} state
+   * @api public
+   */
+
+  page.back = function(path, state) {
+    if (page.len > 0) {
+      // this may need more testing to see if all browsers
+      // wait for the next tick to go back in history
+      history.back();
+      page.len--;
+    } else if (path) {
+      setTimeout(function() {
+        page.show(path, state);
+      });
+    }else{
+      setTimeout(function() {
+        page.show(base, state);
+      });
+    }
+  };
+
+
+  /**
+   * Register route to redirect from one path to other
+   * or just redirect to another route
+   *
+   * @param {string} from - if param 'to' is undefined redirects to 'from'
+   * @param {string=} to
+   * @api public
+   */
+  page.redirect = function(from, to) {
+    // Define route from a path to another
+    if ('string' === typeof from && 'string' === typeof to) {
+      page(from, function(e) {
+        setTimeout(function() {
+          page.replace(/** @type {!string} */ (to));
+        }, 0);
+      });
+    }
+
+    // Wait for the push state and replace it with another
+    if ('string' === typeof from && 'undefined' === typeof to) {
+      setTimeout(function() {
+        page.replace(from);
+      }, 0);
+    }
+  };
+
+  /**
+   * Replace `path` with optional `state` object.
+   *
+   * @param {string} path
+   * @param {Object=} state
+   * @param {boolean=} init
+   * @param {boolean=} dispatch
+   * @return {!Context}
+   * @api public
+   */
+
+
+  page.replace = function(path, state, init, dispatch) {
+    var ctx = new Context(path, state);
+    page.current = ctx.path;
+    ctx.init = init;
+    ctx.save(); // save before dispatching, which may redirect
+    if (false !== dispatch) page.dispatch(ctx);
+    return ctx;
+  };
+
+  /**
+   * Dispatch the given `ctx`.
+   *
+   * @param {Context} ctx
+   * @api private
+   */
+  page.dispatch = function(ctx) {
+    var prev = prevContext,
+      i = 0,
+      j = 0;
+
+    prevContext = ctx;
+
+    function nextExit() {
+      var fn = page.exits[j++];
+      if (!fn) return nextEnter();
+      fn(prev, nextExit);
+    }
+
+    function nextEnter() {
+      var fn = page.callbacks[i++];
+
+      if (ctx.path !== page.current) {
+        ctx.handled = false;
+        return;
+      }
+      if (!fn) return unhandled(ctx);
+      fn(ctx, nextEnter);
+    }
+
+    if (prev) {
+      nextExit();
+    } else {
+      nextEnter();
+    }
+  };
+
+  /**
+   * Unhandled `ctx`. When it's not the initial
+   * popstate then redirect. If you wish to handle
+   * 404s on your own use `page('*', callback)`.
+   *
+   * @param {Context} ctx
+   * @api private
+   */
+  function unhandled(ctx) {
+    if (ctx.handled) return;
+    var current;
+
+    if (hashbang) {
+      current = base + location.hash.replace('#!', '');
+    } else {
+      current = location.pathname + location.search;
+    }
+
+    if (current === ctx.canonicalPath) return;
+    page.stop();
+    ctx.handled = false;
+    location.href = ctx.canonicalPath;
+  }
+
+  /**
+   * Register an exit route on `path` with
+   * callback `fn()`, which will be called
+   * on the previous context when a new
+   * page is visited.
+   */
+  page.exit = function(path, fn) {
+    if (typeof path === 'function') {
+      return page.exit('*', path);
+    }
+
+    var route = new Route(path);
+    for (var i = 1; i < arguments.length; ++i) {
+      page.exits.push(route.middleware(arguments[i]));
+    }
+  };
+
+  /**
+   * Remove URL encoding from the given `str`.
+   * Accommodates whitespace in both x-www-form-urlencoded
+   * and regular percent-encoded form.
+   *
+   * @param {string} val - URL component to decode
+   */
+  function decodeURLEncodedURIComponent(val) {
+    if (typeof val !== 'string') { return val; }
+    return decodeURLComponents ? decodeURIComponent(val.replace(/\+/g, ' ')) : val;
+  }
+
+  /**
+   * Initialize a new "request" `Context`
+   * with the given `path` and optional initial `state`.
+   *
+   * @constructor
+   * @param {string} path
+   * @param {Object=} state
+   * @api public
+   */
+
+  function Context(path, state) {
+    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? '#!' : '') + path;
+    var i = path.indexOf('?');
+
+    this.canonicalPath = path;
+    this.path = path.replace(base, '') || '/';
+    if (hashbang) this.path = this.path.replace('#!', '') || '/';
+
+    this.title = document.title;
+    this.state = state || {};
+    this.state.path = path;
+    this.querystring = ~i ? decodeURLEncodedURIComponent(path.slice(i + 1)) : '';
+    this.pathname = decodeURLEncodedURIComponent(~i ? path.slice(0, i) : path);
+    this.params = {};
+
+    // fragment
+    this.hash = '';
+    if (!hashbang) {
+      if (!~this.path.indexOf('#')) return;
+      var parts = this.path.split('#');
+      this.path = parts[0];
+      this.hash = decodeURLEncodedURIComponent(parts[1]) || '';
+      this.querystring = this.querystring.split('#')[0];
+    }
+  }
+
+  /**
+   * Expose `Context`.
+   */
+
+  page.Context = Context;
+
+  /**
+   * Push state.
+   *
+   * @api private
+   */
+
+  Context.prototype.pushState = function() {
+    page.len++;
+    history.pushState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+  };
+
+  /**
+   * Save the context state.
+   *
+   * @api public
+   */
+
+  Context.prototype.save = function() {
+    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+  };
+
+  /**
+   * Initialize `Route` with the given HTTP `path`,
+   * and an array of `callbacks` and `options`.
+   *
+   * Options:
+   *
+   *   - `sensitive`    enable case-sensitive routes
+   *   - `strict`       enable strict matching for trailing slashes
+   *
+   * @constructor
+   * @param {string} path
+   * @param {Object=} options
+   * @api private
+   */
+
+  function Route(path, options) {
+    options = options || {};
+    this.path = (path === '*') ? '(.*)' : path;
+    this.method = 'GET';
+    this.regexp = pathtoRegexp(this.path,
+      this.keys = [],
+      options);
+  }
+
+  /**
+   * Expose `Route`.
+   */
+
+  page.Route = Route;
+
+  /**
+   * Return route middleware with
+   * the given callback `fn()`.
+   *
+   * @param {Function} fn
+   * @return {Function}
+   * @api public
+   */
+
+  Route.prototype.middleware = function(fn) {
+    var self = this;
+    return function(ctx, next) {
+      if (self.match(ctx.path, ctx.params)) return fn(ctx, next);
+      next();
+    };
+  };
+
+  /**
+   * Check if this route matches `path`, if so
+   * populate `params`.
+   *
+   * @param {string} path
+   * @param {Object} params
+   * @return {boolean}
+   * @api private
+   */
+
+  Route.prototype.match = function(path, params) {
+    var keys = this.keys,
+      qsIndex = path.indexOf('?'),
+      pathname = ~qsIndex ? path.slice(0, qsIndex) : path,
+      m = this.regexp.exec(decodeURIComponent(pathname));
+
+    if (!m) return false;
+
+    for (var i = 1, len = m.length; i < len; ++i) {
+      var key = keys[i - 1];
+      var val = decodeURLEncodedURIComponent(m[i]);
+      if (val !== undefined || !(hasOwnProperty.call(params, key.name))) {
+        params[key.name] = val;
+      }
+    }
+
+    return true;
+  };
+
+
+  /**
+   * Handle "populate" events.
+   */
+
+  var onpopstate = (function () {
+    var loaded = false;
+    if ('undefined' === typeof window) {
+      return;
+    }
+    if (document.readyState === 'complete') {
+      loaded = true;
+    } else {
+      window.addEventListener('load', function() {
+        setTimeout(function() {
+          loaded = true;
+        }, 0);
+      });
+    }
+    return function onpopstate(e) {
+      if (!loaded) return;
+      if (e.state) {
+        var path = e.state.path;
+        page.replace(path, e.state);
+      } else {
+        page.show(location.pathname + location.hash, undefined, undefined, false);
+      }
+    };
+  })();
+  /**
+   * Handle "click" events.
+   */
+
+  function onclick(e) {
+
+    if (1 !== which(e)) return;
+
+    if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+    if (e.defaultPrevented) return;
+
+
+
+    // ensure link
+    // use shadow dom when available
+    var el = e.path ? e.path[0] : e.target;
+    while (el && 'A' !== el.nodeName) el = el.parentNode;
+    if (!el || 'A' !== el.nodeName) return;
+
+
+
+    // Ignore if tag has
+    // 1. "download" attribute
+    // 2. rel="external" attribute
+    if (el.hasAttribute('download') || el.getAttribute('rel') === 'external') return;
+
+    // ensure non-hash for the same path
+    var link = el.getAttribute('href');
+    if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
+
+
+
+    // Check for mailto: in the href
+    if (link && link.indexOf('mailto:') > -1) return;
+
+    // check target
+    if (el.target) return;
+
+    // x-origin
+    if (!sameOrigin(el.href)) return;
+
+
+
+    // rebuild path
+    var path = el.pathname + el.search + (el.hash || '');
+
+    // strip leading "/[drive letter]:" on NW.js on Windows
+    if (typeof process !== 'undefined' && path.match(/^\/[a-zA-Z]:\//)) {
+      path = path.replace(/^\/[a-zA-Z]:\//, '/');
+    }
+
+    // same page
+    var orig = path;
+
+    if (path.indexOf(base) === 0) {
+      path = path.substr(base.length);
+    }
+
+    if (hashbang) path = path.replace('#!', '');
+
+    if (base && orig === path) return;
+
+    e.preventDefault();
+    page.show(orig);
+  }
+
+  /**
+   * Event button.
+   */
+
+  function which(e) {
+    e = e || window.event;
+    return null === e.which ? e.button : e.which;
+  }
+
+  /**
+   * Check if `href` is the same origin.
+   */
+
+  function sameOrigin(href) {
+    var origin = location.protocol + '//' + location.hostname;
+    if (location.port) origin += ':' + location.port;
+    return (href && (0 === href.indexOf(origin)));
+  }
+
+  page.sameOrigin = sameOrigin;
+
+}).call(this,require('_process'))
+},{"_process":2,"path-to-regexp":3}],2:[function(require,module,exports){
+// shim for using process in browser
+
+var process = module.exports = {};
+
+process.nextTick = (function () {
+    var canSetImmediate = typeof window !== 'undefined'
+    && window.setImmediate;
+    var canMutationObserver = typeof window !== 'undefined'
+    && window.MutationObserver;
+    var canPost = typeof window !== 'undefined'
+    && window.postMessage && window.addEventListener
+    ;
+
+    if (canSetImmediate) {
+        return function (f) { return window.setImmediate(f) };
+    }
+
+    var queue = [];
+
+    if (canMutationObserver) {
+        var hiddenDiv = document.createElement("div");
+        var observer = new MutationObserver(function () {
+            var queueList = queue.slice();
+            queue.length = 0;
+            queueList.forEach(function (fn) {
+                fn();
+            });
+        });
+
+        observer.observe(hiddenDiv, { attributes: true });
+
+        return function nextTick(fn) {
+            if (!queue.length) {
+                hiddenDiv.setAttribute('yes', 'no');
+            }
+            queue.push(fn);
+        };
+    }
+
+    if (canPost) {
+        window.addEventListener('message', function (ev) {
+            var source = ev.source;
+            if ((source === window || source === null) && ev.data === 'process-tick') {
+                ev.stopPropagation();
+                if (queue.length > 0) {
+                    var fn = queue.shift();
+                    fn();
+                }
+            }
+        }, true);
+
+        return function nextTick(fn) {
+            queue.push(fn);
+            window.postMessage('process-tick', '*');
+        };
+    }
+
+    return function nextTick(fn) {
+        setTimeout(fn, 0);
+    };
+})();
+
+process.title = 'browser';
+process.browser = true;
+process.env = {};
+process.argv = [];
+
+function noop() {}
+
+process.on = noop;
+process.addListener = noop;
+process.once = noop;
+process.off = noop;
+process.removeListener = noop;
+process.removeAllListeners = noop;
+process.emit = noop;
+
+process.binding = function (name) {
+    throw new Error('process.binding is not supported');
+};
+
+// TODO(shtylman)
+process.cwd = function () { return '/' };
+process.chdir = function (dir) {
+    throw new Error('process.chdir is not supported');
+};
+
+},{}],3:[function(require,module,exports){
+var isarray = require('isarray')
+
+/**
+ * Expose `pathToRegexp`.
+ */
+module.exports = pathToRegexp
+module.exports.parse = parse
+module.exports.compile = compile
+module.exports.tokensToFunction = tokensToFunction
+module.exports.tokensToRegExp = tokensToRegExp
+
+/**
+ * The main path matching regexp utility.
+ *
+ * @type {RegExp}
+ */
+var PATH_REGEXP = new RegExp([
+  // Match escaped characters that would otherwise appear in future matches.
+  // This allows the user to escape special characters that won't transform.
+  '(\\\\.)',
+  // Match Express-style parameters and un-named parameters with a prefix
+  // and optional suffixes. Matches appear as:
+  //
+  // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
+  // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
+  // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
+  '([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^()])+)\\))?|\\(((?:\\\\.|[^()])+)\\))([+*?])?|(\\*))'
+].join('|'), 'g')
+
+/**
+ * Parse a string for the raw tokens.
+ *
+ * @param  {String} str
+ * @return {Array}
+ */
+function parse (str) {
+  var tokens = []
+  var key = 0
+  var index = 0
+  var path = ''
+  var res
+
+  while ((res = PATH_REGEXP.exec(str)) != null) {
+    var m = res[0]
+    var escaped = res[1]
+    var offset = res.index
+    path += str.slice(index, offset)
+    index = offset + m.length
+
+    // Ignore already escaped sequences.
+    if (escaped) {
+      path += escaped[1]
+      continue
+    }
+
+    // Push the current path onto the tokens.
+    if (path) {
+      tokens.push(path)
+      path = ''
+    }
+
+    var prefix = res[2]
+    var name = res[3]
+    var capture = res[4]
+    var group = res[5]
+    var suffix = res[6]
+    var asterisk = res[7]
+
+    var repeat = suffix === '+' || suffix === '*'
+    var optional = suffix === '?' || suffix === '*'
+    var delimiter = prefix || '/'
+    var pattern = capture || group || (asterisk ? '.*' : '[^' + delimiter + ']+?')
+
+    tokens.push({
+      name: name || key++,
+      prefix: prefix || '',
+      delimiter: delimiter,
+      optional: optional,
+      repeat: repeat,
+      pattern: escapeGroup(pattern)
+    })
+  }
+
+  // Match any characters still remaining.
+  if (index < str.length) {
+    path += str.substr(index)
+  }
+
+  // If the path exists, push it onto the end.
+  if (path) {
+    tokens.push(path)
+  }
+
+  return tokens
+}
+
+/**
+ * Compile a string to a template function for the path.
+ *
+ * @param  {String}   str
+ * @return {Function}
+ */
+function compile (str) {
+  return tokensToFunction(parse(str))
+}
+
+/**
+ * Expose a method for transforming tokens into the path function.
+ */
+function tokensToFunction (tokens) {
+  // Compile all the tokens into regexps.
+  var matches = new Array(tokens.length)
+
+  // Compile all the patterns before compilation.
+  for (var i = 0; i < tokens.length; i++) {
+    if (typeof tokens[i] === 'object') {
+      matches[i] = new RegExp('^' + tokens[i].pattern + '$')
+    }
+  }
+
+  return function (obj) {
+    var path = ''
+    var data = obj || {}
+
+    for (var i = 0; i < tokens.length; i++) {
+      var token = tokens[i]
+
+      if (typeof token === 'string') {
+        path += token
+
+        continue
+      }
+
+      var value = data[token.name]
+      var segment
+
+      if (value == null) {
+        if (token.optional) {
+          continue
+        } else {
+          throw new TypeError('Expected "' + token.name + '" to be defined')
+        }
+      }
+
+      if (isarray(value)) {
+        if (!token.repeat) {
+          throw new TypeError('Expected "' + token.name + '" to not repeat, but received "' + value + '"')
+        }
+
+        if (value.length === 0) {
+          if (token.optional) {
+            continue
+          } else {
+            throw new TypeError('Expected "' + token.name + '" to not be empty')
+          }
+        }
+
+        for (var j = 0; j < value.length; j++) {
+          segment = encodeURIComponent(value[j])
+
+          if (!matches[i].test(segment)) {
+            throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '", but received "' + segment + '"')
+          }
+
+          path += (j === 0 ? token.prefix : token.delimiter) + segment
+        }
+
+        continue
+      }
+
+      segment = encodeURIComponent(value)
+
+      if (!matches[i].test(segment)) {
+        throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but received "' + segment + '"')
+      }
+
+      path += token.prefix + segment
+    }
+
+    return path
+  }
+}
+
+/**
+ * Escape a regular expression string.
+ *
+ * @param  {String} str
+ * @return {String}
+ */
+function escapeString (str) {
+  return str.replace(/([.+*?=^!:${}()[\]|\/])/g, '\\$1')
+}
+
+/**
+ * Escape the capturing group by escaping special characters and meaning.
+ *
+ * @param  {String} group
+ * @return {String}
+ */
+function escapeGroup (group) {
+  return group.replace(/([=!:$\/()])/g, '\\$1')
+}
+
+/**
+ * Attach the keys as a property of the regexp.
+ *
+ * @param  {RegExp} re
+ * @param  {Array}  keys
+ * @return {RegExp}
+ */
+function attachKeys (re, keys) {
+  re.keys = keys
+  return re
+}
+
+/**
+ * Get the flags for a regexp from the options.
+ *
+ * @param  {Object} options
+ * @return {String}
+ */
+function flags (options) {
+  return options.sensitive ? '' : 'i'
+}
+
+/**
+ * Pull out keys from a regexp.
+ *
+ * @param  {RegExp} path
+ * @param  {Array}  keys
+ * @return {RegExp}
+ */
+function regexpToRegexp (path, keys) {
+  // Use a negative lookahead to match only capturing groups.
+  var groups = path.source.match(/\((?!\?)/g)
+
+  if (groups) {
+    for (var i = 0; i < groups.length; i++) {
+      keys.push({
+        name: i,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      })
+    }
+  }
+
+  return attachKeys(path, keys)
+}
+
+/**
+ * Transform an array into a regexp.
+ *
+ * @param  {Array}  path
+ * @param  {Array}  keys
+ * @param  {Object} options
+ * @return {RegExp}
+ */
+function arrayToRegexp (path, keys, options) {
+  var parts = []
+
+  for (var i = 0; i < path.length; i++) {
+    parts.push(pathToRegexp(path[i], keys, options).source)
+  }
+
+  var regexp = new RegExp('(?:' + parts.join('|') + ')', flags(options))
+
+  return attachKeys(regexp, keys)
+}
+
+/**
+ * Create a path regexp from string input.
+ *
+ * @param  {String} path
+ * @param  {Array}  keys
+ * @param  {Object} options
+ * @return {RegExp}
+ */
+function stringToRegexp (path, keys, options) {
+  var tokens = parse(path)
+  var re = tokensToRegExp(tokens, options)
+
+  // Attach keys back to the regexp.
+  for (var i = 0; i < tokens.length; i++) {
+    if (typeof tokens[i] !== 'string') {
+      keys.push(tokens[i])
+    }
+  }
+
+  return attachKeys(re, keys)
+}
+
+/**
+ * Expose a function for taking tokens and returning a RegExp.
+ *
+ * @param  {Array}  tokens
+ * @param  {Array}  keys
+ * @param  {Object} options
+ * @return {RegExp}
+ */
+function tokensToRegExp (tokens, options) {
+  options = options || {}
+
+  var strict = options.strict
+  var end = options.end !== false
+  var route = ''
+  var lastToken = tokens[tokens.length - 1]
+  var endsWithSlash = typeof lastToken === 'string' && /\/$/.test(lastToken)
+
+  // Iterate over the tokens and create our regexp string.
+  for (var i = 0; i < tokens.length; i++) {
+    var token = tokens[i]
+
+    if (typeof token === 'string') {
+      route += escapeString(token)
+    } else {
+      var prefix = escapeString(token.prefix)
+      var capture = token.pattern
+
+      if (token.repeat) {
+        capture += '(?:' + prefix + capture + ')*'
+      }
+
+      if (token.optional) {
+        if (prefix) {
+          capture = '(?:' + prefix + '(' + capture + '))?'
+        } else {
+          capture = '(' + capture + ')?'
+        }
+      } else {
+        capture = prefix + '(' + capture + ')'
+      }
+
+      route += capture
+    }
+  }
+
+  // In non-strict mode we allow a slash at the end of match. If the path to
+  // match already ends with a slash, we remove it for consistency. The slash
+  // is valid at the end of a path match, not in the middle. This is important
+  // in non-ending mode, where "/test/" shouldn't match "/test//route".
+  if (!strict) {
+    route = (endsWithSlash ? route.slice(0, -2) : route) + '(?:\\/(?=$))?'
+  }
+
+  if (end) {
+    route += '$'
+  } else {
+    // In non-ending mode, we need the capturing groups to match as much as
+    // possible by using a positive lookahead to the end or next path segment.
+    route += strict && endsWithSlash ? '' : '(?=\\/|$)'
+  }
+
+  return new RegExp('^' + route, flags(options))
+}
+
+/**
+ * Normalize the given path string, returning a regular expression.
+ *
+ * An empty array can be passed in for the keys, which will hold the
+ * placeholder key descriptions. For example, using `/user/:id`, `keys` will
+ * contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
+ *
+ * @param  {(String|RegExp|Array)} path
+ * @param  {Array}                 [keys]
+ * @param  {Object}                [options]
+ * @return {RegExp}
+ */
+function pathToRegexp (path, keys, options) {
+  keys = keys || []
+
+  if (!isarray(keys)) {
+    options = keys
+    keys = []
+  } else if (!options) {
+    options = {}
+  }
+
+  if (path instanceof RegExp) {
+    return regexpToRegexp(path, keys, options)
+  }
+
+  if (isarray(path)) {
+    return arrayToRegexp(path, keys, options)
+  }
+
+  return stringToRegexp(path, keys, options)
+}
+
+},{"isarray":4}],4:[function(require,module,exports){
+module.exports = Array.isArray || function (arr) {
+  return Object.prototype.toString.call(arr) == '[object Array]';
+};
+
+},{}]},{},[1])(1)
+});

--- a/static/js/menu.js
+++ b/static/js/menu.js
@@ -7,8 +7,6 @@
  */
 'use strict';
 
-/* globals App */
-
 // eslint-disable-next-line no-unused-vars
 var Menu = {
    /**
@@ -61,12 +59,7 @@ var Menu = {
     if(e.target.tagName != 'A') {
       return;
     }
-    let view = e.target.dataset.view;
-    if (!view) {
-      return;
-    }
     this.hide();
-    this.selectItem(view);
   },
 
   /**

--- a/static/js/menu.js
+++ b/static/js/menu.js
@@ -21,6 +21,7 @@ var Menu = {
     this.items = [];
     this.items.things = document.getElementById('things-menu-item');
     this.items.adapters = document.getElementById('adapters-menu-item');
+    this.items.settings = document.getElementById('settings-menu-item');
     this.currentItem = 'things';
   },
 
@@ -64,10 +65,8 @@ var Menu = {
     if (!view) {
       return;
     }
-    e.preventDefault();
     this.hide();
     this.selectItem(view);
-    App.selectView(view);
   },
 
   /**

--- a/static/js/on-off-switch.js
+++ b/static/js/on-off-switch.js
@@ -49,7 +49,8 @@ OnOffSwitch.prototype.updateStatus = function() {
   }
   var opts = {
     headers: {
-      'Authorization': `Bearer ${window.API.jwt}`
+      'Authorization': `Bearer ${window.API.jwt}`,
+      'Accept': 'application/json'
     }
   };
   fetch(this.onPropertyUrl, opts).then((function(response) {

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -1,0 +1,22 @@
+/**
+ * Client side URL router.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+'use strict';
+
+/* globals App, page */
+
+// eslint-disable-next-line no-unused-vars
+var Router = {
+  init: function() {
+
+    page('/', '/things');
+    page('/things', App.showThings.bind(App));
+    page('/adapters', App.showAdapters.bind(App));
+    page('/settings', App.showSettings.bind(App));
+    page();
+  }
+};

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -12,9 +12,9 @@
 // eslint-disable-next-line no-unused-vars
 var Router = {
   init: function() {
-
     page('/', '/things');
     page('/things', App.showThings.bind(App));
+    page('/things/:thingId', App.showThings.bind(App));
     page('/adapters', App.showAdapters.bind(App));
     page('/settings', App.showSettings.bind(App));
     page();

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -17,7 +17,12 @@ var SettingsScreen = {
     * Initialise Settings Screen.
     */
     init: function() {
-     fetch('/settings/tunnelinfo')
+      const opts = {
+        headers: {
+          'Accept': 'application/json'
+        }
+      };
+     fetch('/settings/tunnelinfo', opts)
          .then(function (res) {
              return res.text();
          })

--- a/static/js/things.js
+++ b/static/js/things.js
@@ -36,6 +36,7 @@ var ThingsScreen = {
     const opts = {
       headers: {
         'Authorization': `Bearer ${window.API.jwt}`,
+        'Accept': 'application/json'
       }
     };
     // Fetch a list of things from the server


### PR DESCRIPTION
This pull request includes two commits, the first splits routing between a server side Express router (for API requests) and a client side Page.js router (for app requests). The second introduces a basic Thing detail view which currently you can only access by typing in the URL of a Thing directly (until we have more complex Thing types and a UI that makes more sense).

In order to give things URLs in the web app like /things/{thingId} in a nice RESTful way, we need to be able to differentiate between API requests (JSON & WebSockets) and web app requests (HTML etc.).

The first commit splits the API and app routing so that app routing is handled mostly by a client side URL router so we can have a single page app with real URLs which can eventually also work offline using Service Workers.

It turns out this is something Express isn't actually very good at. The best approach I've found so far is to write our own content negotiation middleware which splits routing between API requests and app requests by adding a pseudo path prefix (which the end consumer never sees) based on the contents of the HTTP Accept header. It felt kind of hacky at first, but it actually works quite well.

One issue with the client side router is how to properly handle 404s when a resource doesn't exist, but this seems to be an issue with client side routing in general.

The client side router uses the very lightweight [page.js](https://visionmedia.github.io/page.js/) library which I've manually added to a /static/lib folder. Maybe not the best way of managing dependencies going forward but I didn't want to get into client side dependency management just yet.