### PR TITLE
Redirect HTTP to HTTPS when available

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -11,7 +11,8 @@
 module.exports = {
   cli: false,
   ports: {
-    https: 0 // 0 = find a free open port
+    https: 0, // 0 = find a free open port
+    http: 0,
   },
   adapters : {
     mock: {

--- a/src/router.js
+++ b/src/router.js
@@ -23,7 +23,7 @@ var Router = {
   /**
    * Configure web app routes.
    */
-  configure: function(app, opt) {
+  configure: function(app, options) {
 
     const API_PREFIX = '/api'; // A pseudo path to use for API requests
     const APP_PREFIX = '/app'; // A pseudo path to use for front end requests
@@ -54,7 +54,7 @@ var Router = {
       require('./controllers/login_controller'));
     app.use(API_PREFIX + Constants.SETTINGS_PATH,
       require('./controllers/tunnel_controller'));
-    if (opt.options.debug) {
+    if (options.debug) {
       app.use(API_PREFIX + Constants.DEBUG_PATH,
       require('./controllers/debug_controller'));
     }

--- a/src/test/common.js
+++ b/src/test/common.js
@@ -28,9 +28,8 @@ expect.extend({
   }
 });
 
-let {server, app} = require('../app');
+let {server, httpServer} = require('../app');
 global.server = server;
-global.app = app;
 
 var adapterManager = require('../adapter-manager');
 
@@ -53,9 +52,13 @@ afterEach(async () => {
 
 afterAll(async () => {
   server.close();
-  await e2p(server, 'close');
+  httpServer.close();
+  await Promise.all([
+    e2p(server, 'close'),
+    e2p(httpServer, 'close')
+  ])
 });
 
 module.exports = {
-  mockAdapter, server, chai,
+  mockAdapter, server, chai, httpServer,
 };

--- a/src/test/integration/http-test.js
+++ b/src/test/integration/http-test.js
@@ -1,0 +1,30 @@
+
+const {httpServer, chai} = require('../common');
+const pFinal = require('../promise-final');
+const {TEST_USER, headerAuth} = require('../user');
+const Constants = require('../../constants');
+
+describe('http redirector', function() {
+  it('should redirect GET /', async () => {
+    const res  = await chai.request(httpServer)
+      .get('/');
+    console.log(res);
+    expect(res.status).toBe(200);
+    // chai.request appears to not allow passing followRedirect: false, so
+    // this slight hack is necessary
+    expect(res.request._redirects).toBe(1);
+  });
+  it('should not redirect an authorization-bearing request', async () => {
+    const fakeJwt = 'fakeJwt';
+    const err = await pFinal(chai.request(httpServer)
+      .get(Constants.THINGS_PATH)
+      .set(...headerAuth(fakeJwt)));
+    expect(err.response.status).toBe(403);
+  });
+  it('should not redirect a login POST', async () => {
+    const err = await pFinal(chai.request(httpServer)
+      .post(Constants.LOGIN_PATH)
+      .send(TEST_USER));
+    expect(err.response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
The redirector forbids anything that may have credentials in it while
redirecting everything else to HTTPS. Additionally refactors the server
startup flow to be a bit more straightforward. Most notably, the
`deferredWsRoutes` hack is no longer necessary.

Fix #206