### PR TITLE
Implement setProperty

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -30,3 +30,4 @@ exports.ADD_EVENT_SUBSCRIPTION = 'addEventSubscription';
 exports.PROPERTY_STATUS = 'propertyStatus';
 exports.ACTION_STATUS = 'actionStatus';
 exports.EVENT = 'event';
+exports.ERROR = 'error';

--- a/src/controllers/things_controller.js
+++ b/src/controllers/things_controller.js
@@ -146,7 +146,21 @@ ThingsController.ws('/:thingId/', function(websocket, request) {
   });
 
   websocket.on('message', function(requestText) {
-    let request = JSON.parse(requestText);
+    let request = null;
+    try {
+      request = JSON.parse(requestText);
+    } catch(e) {
+      websocket.send(JSON.stringify({
+        messageType: Constants.ERROR,
+        data: {
+          status: '400 Bad Request',
+          message: 'Parsing request failed',
+          request: request
+        }
+      }));
+      return;
+    }
+
     let device = AdapterManager.getDevice(thingId);
     if (!device) {
       websocket.send(JSON.stringify({

--- a/src/controllers/things_controller.js
+++ b/src/controllers/things_controller.js
@@ -155,7 +155,6 @@ ThingsController.ws('/:thingId/', function(websocket, request) {
         data: {
           status: '400 Bad Request',
           message: 'Parsing request failed',
-          request: request
         }
       }));
       return;

--- a/src/models/things.js
+++ b/src/models/things.js
@@ -125,6 +125,10 @@ var Things = {
    */
    registerWebsocket: function(websocket) {
      this.websockets.push(websocket);
+     websocket.on('close', () => {
+       let index = this.websockets.indexOf(websocket);
+       this.websockets.splice(index, 1);
+     });
    },
 
    /**

--- a/src/test/integration/things-test.js
+++ b/src/test/integration/things-test.js
@@ -13,9 +13,10 @@ const {
 const pFinal = require('../promise-final');
 
 const {
-  openWebSocket,
-  readWebSocket,
-  closeWebSocket
+  webSocketOpen,
+  webSocketRead,
+  webSocketSend,
+  webSocketClose
 } = require('../websocket-util');
 
 var Constants = require('../../constants');
@@ -223,11 +224,11 @@ describe('things/', function() {
   });
 
   it('should send multiple devices during pairing', async () => {
-    let ws = await openWebSocket(Constants.NEW_THINGS_PATH, jwt);
+    let ws = await webSocketOpen(Constants.NEW_THINGS_PATH, jwt);
 
     // We expect things test-4, and test-5 to show up eventually
     const [messages, res] = await Promise.all([
-      readWebSocket(ws, 2),
+      webSocketRead(ws, 2),
       (async () => {
         const res = await chai.request(server)
           .post(Constants.ACTIONS_PATH)
@@ -248,7 +249,7 @@ describe('things/', function() {
     expect(parsedIds.sort()).toEqual(['test-4', 'test-5']);
     expect(res.status).toEqual(201);
 
-    await closeWebSocket(ws);
+    await webSocketClose(ws);
   });
 
   it('should add a device during pairing then create a thing', async () => {
@@ -422,7 +423,7 @@ describe('things/', function() {
   });
 
   it('should receive propertyStatus messages over websocket', async () => {
-    let ws = await openWebSocket(Constants.THINGS_PATH + '/' + TEST_THING.id,
+    let ws = await webSocketOpen(Constants.THINGS_PATH + '/' + TEST_THING.id,
       jwt);
 
     let [res, messages] = await Promise.all([
@@ -434,7 +435,7 @@ describe('things/', function() {
           .set(...headerAuth(jwt))
           .send({on: true});
       })(),
-      readWebSocket(ws, 2)
+      webSocketRead(ws, 2)
     ]);
     expect(res.status).toEqual(200);
     expect(messages[0].messageType).toEqual(Constants.PROPERTY_STATUS);
@@ -444,7 +445,7 @@ describe('things/', function() {
     expect(messages[1].messageType).toEqual(Constants.PROPERTY_STATUS);
     expect(messages[1].data.on).toEqual(true);
 
-    await closeWebSocket(ws);
+    await webSocketClose(ws);
   });
 
 });

--- a/src/test/integration/things-test.js
+++ b/src/test/integration/things-test.js
@@ -42,8 +42,8 @@ describe('things/', function() {
       .post(Constants.THINGS_PATH)
       .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
-      .send(TEST_THING);
-    await mockAdapter().addDevice(id, TEST_THING);
+      .send(desc);
+    await mockAdapter().addDevice(id, desc);
     return res;
   }
 

--- a/src/test/integration/things-test.js
+++ b/src/test/integration/things-test.js
@@ -497,4 +497,25 @@ describe('things/', function() {
 
     await webSocketClose(ws);
   });
+
+  it('should receive an error from sending a malformed message', async () =>
+  {
+    await addDevice();
+    let ws = await webSocketOpen(Constants.THINGS_PATH + '/' + TEST_THING.id,
+      jwt);
+
+    let request = 'good morning friend I am not JSON';
+
+    let [sendError, messages] = await Promise.all([
+      webSocketSend(ws, request),
+      webSocketRead(ws, 1)
+    ]);
+
+    expect(sendError).toBeFalsy();
+
+    let error = messages[0];
+    expect(error.messageType).toBe(Constants.ERROR);
+
+    await webSocketClose(ws);
+  });
 });

--- a/src/test/websocket-util.js
+++ b/src/test/websocket-util.js
@@ -9,7 +9,7 @@ const {server} = require('./common');
  * @param {String} jwt
  * @return {WebSocket}
  */
-async function openWebSocket(path, jwt) {
+async function webSocketOpen(path, jwt) {
   let addr = server.address();
   let socketPath =
     `wss://127.0.0.1:${addr.port}${path}?jwt=${jwt}`;
@@ -25,7 +25,7 @@ async function openWebSocket(path, jwt) {
  * @param {number} expectedMessages
  * @return {Array<Object>} read messages
  */
-async function readWebSocket(ws, expectedMessages) {
+async function webSocketRead(ws, expectedMessages) {
   let messages = [];
   for (let i = 0; i < expectedMessages; i++) {
     const {data} = await e2p(ws, 'message');
@@ -36,15 +36,33 @@ async function readWebSocket(ws, expectedMessages) {
 }
 
 /**
+ * Send a JSON message over a websocket
+ * @param {WebSocket} ws
+ * @param {Object|string} message
+ */
+async function webSocketSend(ws, message) {
+  if (typeof message !== 'string') {
+    message = JSON.stringify(message);
+  }
+
+  await new Promise((resolve) => {
+    ws.send(message, function() {
+      resolve();
+    });
+  });
+}
+
+/**
  * Close a WebSocket and wait for it to be closed
  */
-async function closeWebSocket(ws) {
+async function webSocketClose(ws) {
   ws.close();
   await e2p(ws, 'close');
 }
 
 module.exports = {
-  openWebSocket,
-  readWebSocket,
-  closeWebSocket
+  webSocketOpen,
+  webSocketRead,
+  webSocketSend,
+  webSocketClose
 };

--- a/src/test/websocket-util.js
+++ b/src/test/websocket-util.js
@@ -1,0 +1,50 @@
+const e2p = require('event-to-promise');
+const WebSocket = require('ws');
+
+const {server} = require('./common');
+
+/**
+ * Open a websocket
+ * @param {String} path
+ * @param {String} jwt
+ * @return {WebSocket}
+ */
+async function openWebSocket(path, jwt) {
+  let addr = server.address();
+  let socketPath =
+    `wss://127.0.0.1:${addr.port}${path}?jwt=${jwt}`;
+
+  const ws = new WebSocket(socketPath);
+  await e2p(ws, 'open');
+  return ws;
+}
+
+/**
+ * Read a known amount of messages from a websocket
+ * @param {WebSocket} ws
+ * @param {number} expectedMessages
+ * @return {Array<Object>} read messages
+ */
+async function readWebSocket(ws, expectedMessages) {
+  let messages = [];
+  for (let i = 0; i < expectedMessages; i++) {
+    const {data} = await e2p(ws, 'message');
+    const parsed = JSON.parse(data);
+    messages.push(parsed);
+  }
+  return messages;
+}
+
+/**
+ * Close a WebSocket and wait for it to be closed
+ */
+async function closeWebSocket(ws) {
+  ws.close();
+  await e2p(ws, 'close');
+}
+
+module.exports = {
+  openWebSocket,
+  readWebSocket,
+  closeWebSocket
+};

--- a/src/test/websocket-util.js
+++ b/src/test/websocket-util.js
@@ -16,6 +16,12 @@ async function webSocketOpen(path, jwt) {
 
   const ws = new WebSocket(socketPath);
   await e2p(ws, 'open');
+
+  // Allow the app to handle the websocket open
+  await new Promise(res => {
+    setTimeout(res, 0);
+  });
+
   return ws;
 }
 


### PR DESCRIPTION
This incorporates a fair bit of WebSocket-related work, culminating in implementing support for setProperty.

The other parts are a refactor of the WebSocket test functions to help future work, a fix for a bug in the `/new_things` websocket endpoint,  and a fix for a leak in propertyStatus.