### PR TITLE
Backport run-app.sh from master

### DIFF
--- a/run-app.sh
+++ b/run-app.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+run_app() {
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+
+  sudo /sbin/ldconfig
+
+  echo "nvm version"
+  nvm --version
+  echo "node version"
+  node --version
+  echo "npm version"
+  npm --version
+  echo "Starting gateway ..."
+  node app.js
+}
+
+run_app > ${HOME}/mozilla-iot/gateway/run-app.log 2>&1


### PR DESCRIPTION
This is needed by systemctl scripts which are installed using the prepare-base.sh script.