### PR TITLE
Fix adapter manage to not load adapters twice.

### DIFF
--- a/src/adapter-manager.js
+++ b/src/adapter-manager.js
@@ -38,6 +38,7 @@ class AdapterManager extends EventEmitter {
     this.devices = {};
     this.deferredAdd = null;
     this.deferredRemove = null;
+    this.adaptersLoaded = false;
   }
 
   /**
@@ -314,6 +315,12 @@ class AdapterManager extends EventEmitter {
    * Loads all of the configured adapters from the adapters directory.
    */
   loadAdapters() {
+    if (this.adaptersLoaded) {
+      // This is kind of a hack, but it allows the gateway to restart properly
+      // when switching between http and https modes.
+      return;
+    }
+    this.adaptersLoaded = true;
     var adaptersConfig = config.get('adapters');
     for (var adapterName in adaptersConfig) {
       var adapterConfig = adaptersConfig[adapterName];
@@ -367,11 +374,16 @@ class AdapterManager extends EventEmitter {
    * Unloads all of the loaded adapters.
    */
   unloadAdapters() {
+    if (!this.adaptersLoaded) {
+      // The adapters are not currently loaded, no need to unload.
+      return;
+    }
     for (var adapterId in this.adapters) {
       var adapter = this.adapters[adapterId];
       console.log('Unloading', adapter.name);
       adapter.unload();
     }
+    this.adaptersLoaded = false;
   }
 }
 


### PR DESCRIPTION
This ports PR #274 onto master.

On a first time run of the gateway, the adapter manager loadAdapters
may get called twice. This causes issues if serial ports were previously
open, so this patch makes the second call of loadAdapters be a no-op.