### PR TITLE
Use WS API to update property status

### DIFF
--- a/static/js/on-off-switch.js
+++ b/static/js/on-off-switch.js
@@ -77,20 +77,33 @@ OnOffSwitch.prototype.updateStatus = function() {
       'Accept': 'application/json'
     }
   };
-  fetch(this.onPropertyUrl, opts).then((function(response) {
+
+  fetch(this.onPropertyUrl, opts).then(function(response) {
     return response.json();
-  }).bind(this)).then((function(response) {
-    this.properties.on = response.on;
-    if (response.on === null) {
-      return;
-    } else if(response.on) {
-      this.showOn();
-    } else {
-      this.showOff();
-    }
+  }).then((function(response) {
+    this.onPropertyStatus(response);
   }).bind(this)).catch(function(error) {
     console.error('Error fetching on/off switch status ' + error);
   });
+};
+
+/**
+ * Handle a 'propertyStatus' message
+ * @param {Object} properties - property data
+ */
+OnOffSwitch.prototype.onPropertyStatus = function(data) {
+  if (!data.hasOwnProperty('on')) {
+    return;
+  }
+  this.properties.on = data.on;
+  if (data.on === null) {
+    return;
+  }
+  if (data.on) {
+    this.showOn();
+  } else {
+    this.showOff();
+  }
 };
 
 /**

--- a/static/js/thing.js
+++ b/static/js/thing.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-/* globals App */
+/* globals App, API */
 
 /**
  * Thing constructor.
@@ -32,6 +32,15 @@ var Thing = function(description, format) {
   // Parse base URL of Thing
   if (description.href) {
     this.href = new URL(description.href, App.ORIGIN);
+
+    var wsHref = this.href.href.replace(/^http/, 'ws');
+    this.ws = new WebSocket(wsHref + '?jwt=' + API.jwt);
+    this.ws.addEventListener('message', function(event) {
+      var message = JSON.parse(event.data);
+      if (message.messageType === 'propertyStatus') {
+        this.onPropertyStatus(message.data);
+      }
+    }.bind(this));
   }
   // Parse properties
   if (description.properties) {
@@ -110,4 +119,11 @@ Thing.prototype.handleContextMenu = function(e) {
     }
   });
   window.dispatchEvent(newEvent);
+};
+
+/**
+ * Handle a 'propertyStatus' websocket message
+ * @param {Object} properties - property data
+ */
+Thing.prototype.onPropertyStatus = function(_properties) {
 };


### PR DESCRIPTION
Adds a `ws` property to Thing in the frontend. The OnOffSwitch then listens for `propertyStatus` messages, using them to update the UI. This does not yet use the `setProperty` message to replace the PUT requests. 