### PR TITLE
Add a UI for OTA updating

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,7 @@ exports.LOGIN_PATH = '/login';
 exports.LOG_OUT_PATH = '/log-out';
 exports.SETTINGS_PATH = '/settings';
 exports.COMMANDS_PATH = '/commands';
+exports.UPDATES_PATH = '/updates';
 exports.UPLOADS_PATH = '/uploads';
 exports.DEBUG_PATH = '/debug';
 exports.RULES_PATH = '/rules';

--- a/src/controllers/updates_controller.js
+++ b/src/controllers/updates_controller.js
@@ -1,0 +1,117 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const fetch = require('node-fetch');
+const semver = require('semver');
+const PromiseRouter = require('express-promise-router');
+
+const UpdatesController = PromiseRouter();
+
+function readVersion(packagePath) {
+  return new Promise(function(resolve, reject) {
+    fs.readFile(packagePath, {encoding: 'utf8'}, function(err, data) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      let pkg = JSON.parse(data);
+      if (!semver.valid(pkg.version)) {
+        reject(new Error('invalid gateway semver: ' + pkg.version));
+        return;
+      }
+      resolve(pkg.version);
+    });
+  });
+}
+
+function stat(path) {
+  return new Promise(function(resolve, reject) {
+    fs.stat(path, function(err, stats) {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          resolve(null);
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(stats);
+      }
+    });
+  });
+}
+
+/**
+ * Send the client an object describing the latest release
+ */
+UpdatesController.get('/latest', async function(request, response) {
+  const res = await
+    fetch('https://api.github.com/repos/mozilla-iot/gateway/releases');
+  const releases = await res.json();
+  const latestRelease = releases.filter(release => {
+    return !release.prerelease && !release.draft;
+  })[0];
+  if (!latestRelease) {
+    console.warn('No releases found');
+    response.send({version: null});
+    return;
+  }
+  let releaseVer = latestRelease.tag_name;
+  response.send({version: releaseVer});
+});
+
+/**
+ * Send an object describing the update status of the gateway
+ */
+UpdatesController.get('/status', async function(request, response) {
+  // gateway, gateway_failed, gateway_old
+  // oldVersion -> gateway_old's package.json version
+  // if (gateway_failed.version > thisversion) {
+  //  update failed, last attempt was ctime of gateway_failed
+  // }
+  const currentVersion = await readVersion('package.json');
+  let oldStats = await stat('../gateway_old/package.json');
+  let oldVersion = null;
+
+  let failedStats = await stat('../gateway_failed/package.json');
+  let failedVersion = null;
+
+  if (oldStats) {
+    oldVersion = await readVersion('../gateway_old/package.json')
+  }
+
+  if (failedStats) {
+    failedVersion = await readVersion('../gateway_failed/package.json')
+  }
+
+  if (failedVersion && semver.gt(failedVersion, currentVersion)) {
+    response.send({
+      success: false,
+      version: currentVersion,
+      failedVersion: failedVersion,
+      timestamp: failedStats.ctimeMs
+    });
+  } else {
+    let timestamp = null;
+    if (oldStats) {
+      timestamp = oldStats.ctimeMs;
+    }
+    response.send({
+      success: true,
+      version: currentVersion,
+      oldVersion: oldVersion,
+      timestamp: timestamp
+    });
+  }
+});
+
+UpdatesController.post('/update', async function(request, response) {
+  const child = childProcess.spawn('node', ['tools/check-for-update.js'], {
+    detached: true,
+    stdio: 'ignore'
+  });
+
+  child.unref();
+
+  response.end();
+});
+
+module.exports = UpdatesController;

--- a/src/controllers/updates_controller.js
+++ b/src/controllers/updates_controller.js
@@ -46,6 +46,11 @@ UpdatesController.get('/latest', async function(request, response) {
   const res = await
     fetch('https://api.github.com/repos/mozilla-iot/gateway/releases');
   const releases = await res.json();
+  if (!releases || !releases.filter) {
+    console.warn('API returned invalid releases, rate limit likely exceeded');
+    response.send({version: null});
+    return;
+  }
   const latestRelease = releases.filter(release => {
     return !release.prerelease && !release.draft;
   })[0];

--- a/src/controllers/updates_controller.js
+++ b/src/controllers/updates_controller.js
@@ -104,10 +104,14 @@ UpdatesController.get('/status', async function(request, response) {
 });
 
 UpdatesController.post('/update', async function(request, response) {
-  const child = childProcess.spawn('node', ['tools/check-for-update.js'], {
-    detached: true,
-    stdio: 'ignore'
-  });
+  const child = childProcess.spawn(
+    process.argv[0],
+    ['tools/check-for-update.js'],
+    {
+      detached: true,
+      stdio: 'ignore'
+    }
+  );
 
   child.unref();
 

--- a/src/controllers/updates_controller.js
+++ b/src/controllers/updates_controller.js
@@ -92,12 +92,12 @@ UpdatesController.get('/status', async function(request, response) {
       success: false,
       version: currentVersion,
       failedVersion: failedVersion,
-      timestamp: failedStats.ctimeMs
+      timestamp: failedStats.ctime
     });
   } else {
     let timestamp = null;
     if (oldStats) {
-      timestamp = oldStats.ctimeMs;
+      timestamp = oldStats.ctime;
     }
     response.send({
       success: true,

--- a/src/controllers/updates_controller.js
+++ b/src/controllers/updates_controller.js
@@ -104,16 +104,8 @@ UpdatesController.get('/status', async function(request, response) {
 });
 
 UpdatesController.post('/update', async function(request, response) {
-  const child = childProcess.spawn(
-    process.argv[0],
-    ['tools/check-for-update.js'],
-    {
-      detached: true,
-      stdio: 'ignore'
-    }
-  );
-
-  child.unref();
+  childProcess.exec('sudo systemctl start ' +
+    'mozilla-iot-gateway.check-for-update.service');
 
   response.end();
 });

--- a/src/router.js
+++ b/src/router.js
@@ -78,6 +78,8 @@ var Router = {
       auth, require('./controllers/uploads_controller'));
     app.use(API_PREFIX + Constants.COMMANDS_PATH,
       auth, require('./controllers/commands_controller'));
+    app.use(API_PREFIX + Constants.UPDATES_PATH,
+      auth, require('./controllers/updates_controller'));
 
     let rulesEngine = require('./rules-engine/index.js');
     app.use(API_PREFIX + Constants.RULES_PATH, auth, rulesEngine);

--- a/src/test/integration/updates-test.js
+++ b/src/test/integration/updates-test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/* globals it */
+
+const nock = require('nock');
+
+const {server, chai} = require('../common');
+const Constants = require('../../constants');
+const {
+  TEST_USER,
+  createUser,
+  headerAuth,
+} = require('../user');
+
+const releases = [
+  {
+    prerelease: false,
+    draft: true,
+    tag_name: '0.1.2'
+  },
+  {
+    prerelease: true,
+    draft: false,
+    tag_name: '0.1.1'
+  },
+  {
+    prerelease: false,
+    draft: false,
+    tag_name: '0.1.0'
+  },
+  {
+    prerelease: false,
+    draft: false,
+    tag_name: '0.0.19'
+  },
+];
+
+describe('updates/', function() {
+  let jwt;
+  beforeEach(async () => {
+    jwt = await createUser(server, TEST_USER);
+  });
+
+  it('should get /latest with a normal response', async() => {
+    nock('https://api.github.com')
+      .get('/repos/mozilla-iot/gateway/releases')
+      .reply(200, releases);
+
+    const res = await chai.request(server)
+      .get(Constants.UPDATES_PATH + '/latest')
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(200);
+    console.log(res.body);
+    expect(res.body.version).toEqual('0.1.0');
+  });
+
+  it('should get /latest with no good releases', async() => {
+    nock('https://api.github.com')
+      .get('/repos/mozilla-iot/gateway/releases')
+      .reply(200, releases.slice(0, 2));
+
+    const res = await chai.request(server)
+      .get(Constants.UPDATES_PATH + '/latest')
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(200);
+    expect(res.body.version).toBeFalsy();
+  });
+
+  it('should get /latest with a strange error', async() => {
+    nock('https://api.github.com')
+      .get('/repos/mozilla-iot/gateway/releases')
+      .reply(200, {error: true});
+
+    const res = await chai.request(server)
+      .get(Constants.UPDATES_PATH + '/latest')
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(200);
+    expect(res.body.version).toBeFalsy();
+  });
+
+  it('GET /status', async() => {
+    const res = await chai.request(server)
+      .get(Constants.UPDATES_PATH + '/status')
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toHaveProperty('success');
+    expect(res.body).toHaveProperty('version');
+  });
+});
+

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -90,13 +90,14 @@
           <li class="settings-item"><a id="domain-settings-link" href="/settings/domain">Domain</a></li>
           <li class="settings-item"><a id="user-settings-link" href="/settings/users">Users</a></li>
           <li class="settings-item"><a id="experiment-settings-link" href="/settings/experiments">Experiments</a></li>
+          <li class="settings-item"><a id="update-settings-link" href="/settings/updates">Updates</a></li>
         </ul>
       </nav>
       <section id="domain-settings" class="hidden settings-section">
-        <div id="current-domain"></div>
+        <div id="current-domain" class="settings-container"></div>
       </section>
       <section id="user-settings" class="hidden settings-section">
-        <div id="current-user">
+        <div id="current-user" class="settings-container">
           <span id="current-user-name"></span><span id="current-user-name"></span>
           <span id="current-user-email"></span><span id="current-user-email"></span>
         </div>
@@ -115,6 +116,19 @@
           <li id="rules-experiment-item" class="experiment-item">
             <input id="rules-experiment-checkbox" class="experiment-checkbox" type="checkbox">
             <label for="rules-experiment-checkbox">Rules</label>
+          </li>
+        </ul>
+      </section>
+      <section id="update-settings" class="hidden settings-section">
+        <ul>
+          <!-- TODO(hobinjk): allow disabling automatic updates -->
+          <li class="update-item" id="up-to-date-container">
+            <p id="update-settings-up-to-date"></p>
+            <button id="update-now" class="text-button hidden">Update Now</button>
+          </li>
+          <li class="update-item">
+            <p id="update-settings-version"></p>
+            <p id="update-settings-status"></p>
           </li>
         </ul>
       </section>

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -59,6 +59,9 @@
 #experiment-settings-link {
   background-image: url('../images/experiments-icon.png');
 }
+#update-settings-link {
+  background-image: url('../images/update-icon.svg');
+}
 
 .settings-section {
   position: fixed;
@@ -74,22 +77,7 @@
   transform: translateX(100%);
 }
 
-#current-domain {
-  position: relative;
-  color: #fff;
-  background-color: #48779a;
-  border-radius: 0.5rem;
-  padding: 2rem;
-  color: #fff;
-  text-align: left;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 1.4rem;
-  max-width: 60rem;
-  margin: 0 auto;
-}
-
-#current-user {
+.settings-container {
   position: relative;
   color: #fff;
   background-color: #48779a;
@@ -113,7 +101,7 @@
   color: #ccc;
 }
 
-#experiment-settings ul {
+#experiment-settings ul, #update-settings ul {
   position: relative;
   top: 50%;
   transform: translateY(-50%);
@@ -124,7 +112,7 @@
   padding: 2rem;
 }
 
-.experiment-item {
+.experiment-item, .update-item {
   display: block;
   margin: 1rem 0;
   font-size: 1.8rem;
@@ -136,6 +124,10 @@
   background-position: 1rem;
   background-size: 3.2rem;
   background-repeat: no-repeat;
+}
+
+.update-item {
+  padding: 2rem;
 }
 
 .experiment-item label {
@@ -181,4 +173,27 @@
 
 #rules-experiment-item {
   background-image: url('../images/rules-icon.png');
+}
+
+#update-now.hidden {
+  display: none;
+}
+
+#update-settings > .settings-container {
+  font-size: 1.8rem;
+}
+
+#up-to-date-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+#update-now {
+  font-size: 1.8rem;
+  padding: 1.8rem;
+  margin-left: 1rem;
+  background: #305067;
+}
+
+#update-settings-up-to-date {
 }

--- a/static/images/update-icon.svg
+++ b/static/images/update-icon.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="32" height="32" viewBox="0 0 32 32">
+  <path stroke="#fff" stroke-width="3px" stroke-linecap="round" d="M 16,9 L 16,24 M 16,9 L 11,14 M 16,9 L 21,14"/>
+</svg>

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -194,6 +194,22 @@
           reject(error);
         });
       });
+    },
+
+    getUpdateStatus: function() {
+      return fetch('/updates/status',
+        {headers: this.headers()}
+      ).then(res => {
+        return res.json();
+      });
+    },
+
+    getUpdateLatest: function() {
+      return fetch('/updates/latest',
+        {headers: this.headers()}
+      ).then(res => {
+        return res.json();
+      });
     }
   };
 }());

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -238,20 +238,23 @@ var SettingsScreen = {
     }).then(function() {
       updateNow.textContent = 'In Progress'
       let isDown = false;
-      let interval = setInterval(function() {
+      function checkStatus() {
         API.getUpdateStatus().then(function() {
           if (isDown) {
-            clearInterval(interval);
             SettingsScreen.showUpdateSettings();
             updateNow.textContent = 'Update Now';
+          } else {
+            setTimeout(checkStatus, 5000);
           }
         }).catch(function() {
           if (!isDown) {
             updateNow.textContent = 'Restarting';
             isDown = true;
           }
+          setTimeout(checkStatus, 5000);
         });
-      }, 1000);
+      }
+      checkStatus();
     }).catch(function() {
       updateNow.textContent = 'Error';
     });

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -240,13 +240,16 @@ var SettingsScreen = {
         API.getUpdateStatus().then(() => {
           if (isDown) {
             clearInterval(interval);
-            updateNow.textContent = 'Update Now';
             this.showUpdateSettings();
+            updateNow.textContent = 'Update Now';
           }
         }).catch(() => {
-          isDown = true;
+          if (!isDown) {
+            updateNow.textContent = 'Restarting';
+            isDown = true;
+          }
         });
-      });
+      }, 1000);
     }).catch(function() {
       updateNow.textContent = 'Error';
     });

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -233,17 +233,17 @@ var SettingsScreen = {
     fetch('/updates/update', {
       headers: API.headers(),
       method: 'POST'
-    }).then(() => {
+    }).then(function() {
       updateNow.textContent = 'In Progress'
       let isDown = false;
-      let interval = setInterval(() => {
-        API.getUpdateStatus().then(() => {
+      let interval = setInterval(function() {
+        API.getUpdateStatus().then(function() {
           if (isDown) {
             clearInterval(interval);
-            this.showUpdateSettings();
+            SettingsScreen.showUpdateSettings();
             updateNow.textContent = 'Update Now';
           }
-        }).catch(() => {
+        }).catch(function() {
           if (!isDown) {
             updateNow.textContent = 'Restarting';
             isDown = true;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -203,9 +203,11 @@ var SettingsScreen = {
         // Update available
         upToDateElt.textContent = 'New version available';
         updateNow.classList.remove('hidden');
+        updateNow.classList.remove('disabled');
       } else {
         // All up to date!
         upToDateElt.textContent = 'Your system is up to date';
+        updateNow.classList.add('hidden');
       }
       versionElt.textContent = `Current version: ${status.version}`;
       let statusText = 'Last update: ';

--- a/tools/check-for-update.sh
+++ b/tools/check-for-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+
+node tools/check-for-update.js

--- a/tools/rollback.sh
+++ b/tools/rollback.sh
@@ -14,12 +14,12 @@ function recentEnough() {
   let elapsed=now-changed
   # if less than 60 * 60 * 24 * 14 seconds have passed
   if [ $elapsed -lt 1209600 ]; then
-    return 1
+    return 0 # successful exit
   fi
-  return 0
+  return 1
 }
 
-if [ -d "gateway_old" ] && [ ! -z $(recentEnough "gateway_old") ]; then
+if [ -d "gateway_old" ] && $(recentEnough "gateway_old"); then
   rm -fr gateway_failed
   mv gateway gateway_failed
   mv gateway_old gateway

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -64,4 +64,5 @@ rm -fr gateway_old
 
 mv $gateway_old gateway_old
 mv /tmp/gateway gateway
+touch gateway_old/package.json
 sudo systemctl start mozilla-iot-gateway.service


### PR DESCRIPTION
Looks like this:
<img width="605" alt="screen shot 2017-09-21 at 2 22 03 pm" src="https://user-images.githubusercontent.com/2776089/30711948-52608f1c-9ed8-11e7-904b-465fd38557f4.png">

<img width="765" alt="screen shot 2017-09-21 at 2 43 37 pm" src="https://user-images.githubusercontent.com/2776089/30712811-4c304ac6-9edb-11e7-8051-3c03a74b9f10.png">


To test, run `image/prepare-base.sh` to put the unit descriptions into place, then replace "mozilla-iot" with "hobinjk" in `src/controllers/updates_controller.js` and `tools/check-for-update.js`.

I'd recommend also commenting out the OnFailure in `mozilla-iot-gateway.service` so that any crashes caused by local development will not make the Gateway think it has to rollback an update. Running `sudo systemctl disable mozilla-iot-gateway.check-for-update.timer` will disable automatic updates for now.