### PR TITLE
Test Rules Engine's rule execution

### DIFF
--- a/src/rules-engine/Property.js
+++ b/src/rules-engine/Property.js
@@ -5,6 +5,7 @@
  */
 
 const assert = require('assert');
+const e2p = require('event-to-promise');
 const fetch = require('node-fetch');
 const storage = require('node-persist');
 const winston = require('winston');
@@ -67,7 +68,6 @@ class Property extends EventEmitter {
    */
   async getHref() {
     let href = await storage.getItem('RulesEngine.gateway') + this.href;
-    winston.log('getHref', href);
     return href;
   }
 
@@ -129,6 +129,7 @@ class Property extends EventEmitter {
 
     this.ws = new WebSocket(wsHref);
     this.ws.on('message', this.onMessage);
+    await e2p(this.ws, 'open');
   }
 
   onMessage(text) {

--- a/src/rules-engine/triggers/LevelTrigger.js
+++ b/src/rules-engine/triggers/LevelTrigger.js
@@ -51,7 +51,7 @@ class LevelTrigger extends PropertyTrigger {
   onValueChanged(propValue) {
     let on = false;
 
-    switch (this.type) {
+    switch (this.levelType) {
       case LevelTriggerTypes.LESS:
         if (propValue < this.level) {
           on = true;

--- a/src/rules-engine/triggers/PropertyTrigger.js
+++ b/src/rules-engine/triggers/PropertyTrigger.js
@@ -28,9 +28,9 @@ class PropertyTrigger extends Trigger {
     );
   }
 
-  start() {
+  async start() {
     this.property.on(Events.VALUE_CHANGED, this.onValueChanged);
-    this.property.start();
+    await this.property.start();
   }
 
   onValueChanged(_value) {

--- a/src/test/integration/settings-test.js
+++ b/src/test/integration/settings-test.js
@@ -6,7 +6,6 @@
 const {server, chai} = require('../common');
 const pFinal = require('../promise-final');
 const storage = require('node-persist');
-const config = require('config');
 const {
   TEST_USER,
   createUser,
@@ -20,11 +19,7 @@ describe('settings/', function() {
   beforeEach(async () => {
     jwt = await createUser(server, TEST_USER);
     // Clear settings storage
-    storage.init({
-      dir: config.get('settings.directory')
-    }).then(async () => {
-      await storage.clear();
-    });
+    await storage.clear();
   });
 
   it('Fail to get a setting that hasnt been set', async () => {

--- a/src/test/rules-engine/index-test.js
+++ b/src/test/rules-engine/index-test.js
@@ -1,4 +1,8 @@
-const {server, chai} = require('../common');
+const config = require('config');
+const storage = require('node-persist');
+
+const {server, chai, mockAdapter} = require('../common');
+
 const pFinal = require('../promise-final');
 const {
   TEST_USER,
@@ -8,13 +12,54 @@ const {
 
 const Constants = require('../../constants');
 
+const {
+  webSocketOpen,
+  webSocketRead,
+  webSocketClose
+} = require('../websocket-util');
+
+const thingLight1 = {
+  id: 'light1',
+  name: 'light1',
+  type: 'onOffSwitch',
+  properties: {
+    on: {type: 'boolean', value: false},
+    hue: {type: 'number', value: 0},
+    sat: {type: 'number', value: 0},
+    bri: {type: 'number', value: 100}
+  }
+};
+
+const thingLight2 = {
+  id: 'light2',
+  name: 'light2',
+  type: 'onOffSwitch',
+  properties: {
+    on: {type: 'boolean', value: false},
+    hue: {type: 'number', value: 0},
+    sat: {type: 'number', value: 0},
+    bri: {type: 'number', value: 100}
+  }
+};
+
+const thingLight3 = {
+  id: 'light3',
+  name: 'light3',
+  type: 'onOffSwitch',
+  properties: {
+    on: {type: 'boolean', value: false},
+    hue: {type: 'number', value: 0},
+    sat: {type: 'number', value: 0},
+    bri: {type: 'number', value: 100}
+  }
+};
+
 const testRule = {
   trigger: {
     property: {
       name: 'on',
       type: 'boolean',
-      href:
-        '/things/light1/properties/on'
+      href: '/things/light1/properties/on'
     },
     type: 'BooleanTrigger',
     onValue: true
@@ -23,7 +68,7 @@ const testRule = {
     property: {
       name: 'on',
       type: 'boolean',
-      href: '/things/light1/properties/on'
+      href: '/things/light2/properties/on'
     },
     type: 'PulseEffect',
     value: true
@@ -40,25 +85,77 @@ const numberTestRule = {
         '/things/light2/properties/hue'
     },
     type: 'LevelTrigger',
-    levelType: 'LESS',
+    levelType: 'GREATER',
     level: 120
   },
   effect: {
     property: {
-      name: 'sat',
+      name: 'bri',
       type: 'number',
-      href: '/things/light2/properties/sat'
+      href: '/things/light3/properties/bri'
     },
     type: 'SetEffect',
     value: 30
   }
 };
 
-describe('index router', function() {
+const mixedTestRule = {
+  name: 'Mixed Test Rule',
+  trigger: {
+    property: {
+      name: 'bri',
+      type: 'number',
+      href:
+        '/things/light3/properties/bri'
+    },
+    type: 'LevelTrigger',
+    levelType: 'LESS',
+    level: 50
+  },
+  effect: {
+    property: {
+      name: 'on',
+      type: 'boolean',
+      href: '/things/light3/properties/on'
+    },
+    type: 'PulseEffect',
+    value: true
+  }
+};
+
+describe('rules engine', function() {
   let ruleId = null, jwt;
+
+  async function addDevice(desc) {
+    const {id} = desc;
+    const res = await chai.request(server)
+      .post(Constants.THINGS_PATH)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt))
+      .send(desc);
+    await mockAdapter().addDevice(id, desc);
+    return res;
+  }
+
+  async function deleteRule(id) {
+    let res = await chai.request(server)
+      .delete(Constants.RULES_PATH + '/' + id)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt))
+      .send();
+    expect(res.status).toEqual(200);
+  }
 
   beforeEach(async () => {
     jwt = await createUser(server, TEST_USER);
+    // jest's lifecycle is weird and invalidates the engine's first JWT
+    await storage.init({
+      dir: config.get('settings.directory')
+    });
+    await storage.setItem('RulesEngine.jwt', jwt);
+    await addDevice(thingLight1);
+    await addDevice(thingLight2);
+    await addDevice(thingLight3);
   });
 
   it('gets a list of 0 rules', async () => {
@@ -145,14 +242,9 @@ describe('index router', function() {
   });
 
   it('deletes this rule', async () => {
-    let res = await chai.request(server)
-      .delete(Constants.RULES_PATH + '/' + ruleId)
-      .set('Accept', 'application/json')
-      .set(...headerAuth(jwt))
-      .send();
-    expect(res.status).toEqual(200);
+    await deleteRule(ruleId);
 
-    res = await chai.request(server)
+    let res = await chai.request(server)
       .get(Constants.RULES_PATH)
       .set('Accept', 'application/json')
       .set(...headerAuth(jwt))
@@ -179,4 +271,65 @@ describe('index router', function() {
     expect(err.response.status).toEqual(404);
   });
 
+  it('creates and simulates two rules', async () => {
+    let res = await chai.request(server)
+      .post(Constants.RULES_PATH)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt))
+      .send(numberTestRule);
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toHaveProperty('id');
+    let numberTestRuleId = res.body.id;
+
+    res = await chai.request(server)
+      .post(Constants.RULES_PATH)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt))
+      .send(mixedTestRule);
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toHaveProperty('id');
+    let mixedTestRuleId = res.body.id;
+
+    res = await chai.request(server)
+      .get(Constants.RULES_PATH)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+    expect(res.status).toEqual(200);
+    expect(Array.isArray(res.body)).toBeTruthy();
+    expect(res.body.length).toEqual(2);
+    expect(res.body[0]).toMatchObject(numberTestRule);
+    expect(res.body[1]).toMatchObject(mixedTestRule);
+
+    let ws = await webSocketOpen(Constants.THINGS_PATH + `/${thingLight3.id}`,
+      jwt);
+
+    // The chain we're expecting is light2.hue > 120 sets light3.bri to 30
+    // which sets light3.on to true
+    let [resPut, messages] = await Promise.all([
+      chai.request(server)
+        .put(Constants.THINGS_PATH + '/' + thingLight2.id + '/properties/hue')
+        .set('Accept', 'application/json')
+        .set(...headerAuth(jwt))
+        .send({hue: 150}),
+      webSocketRead(ws, 2)
+    ]);
+    expect(resPut.status).toEqual(200);
+
+    expect(Array.isArray(messages)).toBeTruthy();
+    expect(messages.length).toEqual(2);
+    expect(messages[0]).toMatchObject({
+      messageType: Constants.PROPERTY_STATUS,
+      data: {bri: 30}
+    });
+    expect(messages[1]).toMatchObject({
+      messageType: Constants.PROPERTY_STATUS,
+      data: {on: true}
+    });
+
+    await deleteRule(numberTestRuleId);
+    await deleteRule(mixedTestRuleId);
+    await webSocketClose(ws);
+ });
 });

--- a/src/test/rules-engine/index-test.js
+++ b/src/test/rules-engine/index-test.js
@@ -1,4 +1,3 @@
-const config = require('config');
 const storage = require('node-persist');
 
 const {server, chai, mockAdapter} = require('../common');
@@ -149,9 +148,6 @@ describe('rules engine', function() {
   beforeEach(async () => {
     jwt = await createUser(server, TEST_USER);
     // jest's lifecycle is weird and invalidates the engine's first JWT
-    await storage.init({
-      dir: config.get('settings.directory')
-    });
     await storage.setItem('RulesEngine.jwt', jwt);
     await addDevice(thingLight1);
     await addDevice(thingLight2);


### PR DESCRIPTION
This takes advantage of the fact that the rules engine is part of the gateway to perform a complete test of its rule execution. Notably this also solves an intermittent issue where `storage.init` calls in tests could race and make everything sad.