### PR TITLE
Fix run-tests.sh to use proper directory for tools.

### DIFF
--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -3,7 +3,7 @@
 SCRIPTDIR="$(dirname ""$0"")"
 
 if [ ! -f "certificate.pem" ]; then
-  ${SCRIPTDIR}/../tools/make-self-signed-cert.sh
+  ${SCRIPTDIR}/../../tools/make-self-signed-cert.sh
 fi
 
 jest


### PR DESCRIPTION
It looks like the location of run-tests.sh got moved, which breaks the call to make-self-signed-cert.sh when run on a clean git tree.