### PR TITLE
Mock node-persist

### DIFF
--- a/__mocks__/node-persist.js
+++ b/__mocks__/node-persist.js
@@ -1,0 +1,33 @@
+const storage = jest.genMockFromModule('node-persist');
+
+let data = {};
+
+storage.init = function() {
+  return Promise.resolve();
+};
+
+storage.clear = function() {
+  data = {};
+  return Promise.resolve();
+};
+
+storage.getItem = function(key) {
+  if (!data.hasOwnProperty(key)) {
+    return Promise.resolve();
+  }
+  // Duplicate node-persist's copying logic
+  let copiedValue = JSON.parse(JSON.stringify(data[key]));
+  return Promise.resolve(copiedValue);
+};
+
+storage.setItem = function(key, value) {
+  data[key] = value;
+  return Promise.resolve();
+};
+
+storage.removeItem = function(key) {
+  delete data[key];
+  return Promise.resolve();
+};
+
+module.exports = storage;


### PR DESCRIPTION
Jest runs all tests in parallel. If any test clears `node-persist` while
another test is initializing it, the two calls can race and cause the
initialization of `node-persist` to see an inconsistent filesystem
state.

This mocks `node-persist` with an in-memory store to fix the race
conditions.