### PR TITLE
Fix node-persist race conditions

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -45,7 +45,7 @@ module.exports = {
     removeBeforeOpen: false,
   },
   settings: {
-    directory: './settings/', // Directory to store settings in
+    directory: './settings', // Directory to store settings in
   },
   uploads: {
     directory: '../static/uploads/' // Directory to store uploads in

--- a/config/test.js
+++ b/config/test.js
@@ -31,7 +31,7 @@ module.exports = {
     removeBeforeOpen: false,
   },
   settings: {
-    directory: './test-settings/'
+    directory: './test-settings'
   },
   uploads: {
     directory: '../../static/uploads/' // Directory to store uploads in


### PR DESCRIPTION
Place each test's node-persist settings in a different directory. After
the test finishes, clear and remove this settings directory.