### PR TITLE
Lower bcrypt rounds in tests

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -62,5 +62,5 @@ module.exports = {
     pagekite_cmd: './pagekite.py',
     port: 443
   },
-  bcryptRounds: 10
+  bcryptRounds: 0
 };

--- a/config/default.js
+++ b/config/default.js
@@ -61,5 +61,6 @@ module.exports = {
     domain: 'mozilla-iot.org',
     pagekite_cmd: './pagekite.py',
     port: 443
-  }
+  },
+  bcryptRounds: 10
 };

--- a/config/default.js
+++ b/config/default.js
@@ -61,6 +61,5 @@ module.exports = {
     domain: 'mozilla-iot.org',
     pagekite_cmd: './pagekite.py',
     port: 443
-  },
-  bcryptRounds: 0
+  }
 };

--- a/config/test.js
+++ b/config/test.js
@@ -39,5 +39,6 @@ module.exports = {
   authentication: {
     enabled: true,
     defaultUser: null
-  }
+  },
+  bcryptRounds: 2
 };

--- a/src/passwords.js
+++ b/src/passwords.js
@@ -7,6 +7,9 @@
  */
 
 const bcrypt = require('bcryptjs');
+const config = require('config');
+
+const rounds = config.get('bcryptRounds');
 
 module.exports = {
   /**
@@ -15,7 +18,7 @@ module.exports = {
    * @return {Promise<String>} hashed password
    */
   hash: function(password) {
-    return bcrypt.hash(password, 10);
+    return bcrypt.hash(password, rounds);
   },
 
   /**
@@ -26,7 +29,7 @@ module.exports = {
    * @return {String} hashed password
    */
   hashSync: function(password) {
-    return bcrypt.hashSync(password, 10);
+    return bcrypt.hashSync(password, rounds);
   },
 
   /**

--- a/src/passwords.js
+++ b/src/passwords.js
@@ -9,7 +9,10 @@
 const bcrypt = require('bcryptjs');
 const config = require('config');
 
-const rounds = config.get('bcryptRounds');
+let rounds;
+if (config.has('bcryptRounds')) {
+  rounds = config.get('bcryptRounds');
+}
 
 module.exports = {
   /**


### PR DESCRIPTION
This keeps the same security in the default configuration while reducing the amount of time required to run the tests by 1/3.