### PR TITLE
Fix hangs in ZigBee controller

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -69,5 +69,6 @@ module.exports = {
     domain: 'mozilla-iot.org',
     pagekite_cmd: './pagekite.py',
     port: 443
-  }
+  },
+  bcryptRounds: 2
 };

--- a/src/adapters/zigbee/zb-node.js
+++ b/src/adapters/zigbee/zb-node.js
@@ -277,9 +277,12 @@ class ZigBeeNode extends Device {
     this.adapter.sendFrames(frames);
   }
 
-  sendZclFrame(property, zclData) {
+  sendZclFrameWaitExplicitRxResolve(property, zclData) {
     var frame = this.makeZclFrame(property, zclData);
-    this.adapter.sendFrame(frame);
+    this.adapter.sendFrameWaitFrameResolve(frame, {
+      type: C.FRAME_TYPE.ZIGBEE_EXPLICIT_RX,
+      remote64: frame.destination64,
+    }, property);
   }
 }
 


### PR DESCRIPTION
There were 2 problems:
1 - Sometimes a Transmit Status response would be lost, which
    caused the command queue to hang waiting for a response
    that wouldn't arrive. This was fixed by waiting for the
    response packet to set command instead.
2 - If commands were set fast enough, then the device would get
    into a state where it was already in the desired state, and
    subsequently it wouldn't generate a report since it didn't
    detect a value change. Rather than wait for the report, we
    now resolve the promise when we get confirmation that set command
    was sent.