### PR TITLE
Support redirect behind forwarding

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -16,6 +16,9 @@ module.exports = {
     https: 4443,
     http:  8080
   },
+  // Whether the gateway is behind port forwarding and should use simplified
+  // port-free urls
+  behindForwarding: true,
   adapters : {
     gpio: {
       enabled: false,

--- a/config/test.js
+++ b/config/test.js
@@ -14,6 +14,7 @@ module.exports = {
     https: 0, // 0 = find a free open port
     http: 0,
   },
+  behindForwarding: false,
   adapters : {
     Mock: {
       enabled: true,

--- a/src/app.js
+++ b/src/app.js
@@ -222,7 +222,8 @@ function createRedirectApp(port) {
       return;
     }
     let httpsUrl = 'https://' + request.hostname;
-    if (port !== 443) {
+    // If we're behind forwarding we can redirect to the port-free https url
+    if (port !== 443 && !config.get('behindForwarding')) {
       httpsUrl += ':' + port
     }
     httpsUrl += request.url;


### PR DESCRIPTION
By default localhost:8080 (which localhost:80 forwards to on the RPi) willl now redirect to localhost:443 instead of localhost:4443.

Note that this may require some config editing in local setups