### PR TITLE
Fix background_color key

### DIFF
--- a/static/app.webmanifest
+++ b/static/app.webmanifest
@@ -9,5 +9,5 @@
     "sizes": "256x256",
     "type": "image/png"
   }],
-  "background-color": "#5d9bc7"
+  "background_color": "#5d9bc7"
 }


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/Manifest it's an
underscore, not a hyphen.