### PR TITLE
Point pyconf dependency at mozilla-iot fork.

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
     },
     "setupTestFrameworkScriptFile": "<rootDir>/src/test/common.js",
     "testEnvironment": "node"
+  },
+  "resolutions": {
+    "pyconf": "https://github.com/mozilla-iot/node-config-python"
   }
 }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "testEnvironment": "node"
   },
   "resolutions": {
-    "le-store-certbot": "https://github.com/mozilla-iot/le-store-certbot",
-    "pyconf": "https://github.com/mozilla-iot/node-config-python"
+    "le-store-certbot": "https://github.com/mozilla-iot/le-store-certbot/tarball/master",
+    "pyconf": "https://github.com/mozilla-iot/node-config-python/tarball/master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "testEnvironment": "node"
   },
   "resolutions": {
+    "le-store-certbot": "https://github.com/mozilla-iot/le-store-certbot",
     "pyconf": "https://github.com/mozilla-iot/node-config-python"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3292,9 +3292,9 @@ le-sni-auto@^2.1.0:
   dependencies:
     bluebird "^3.4.1"
 
-le-store-certbot@^2.0.3:
+le-store-certbot@^2.0.3, "le-store-certbot@https://github.com/mozilla-iot/le-store-certbot":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/le-store-certbot/-/le-store-certbot-2.0.5.tgz#b53fcfc177bdf00ea88812d0de673a0de0fe3491"
+  resolved "https://github.com/mozilla-iot/le-store-certbot#0df0a16d655e30429d5d08522bae70da5f2d58f8"
   dependencies:
     bluebird "^3.4.1"
     mkdirp "^0.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3292,9 +3292,9 @@ le-sni-auto@^2.1.0:
   dependencies:
     bluebird "^3.4.1"
 
-le-store-certbot@^2.0.3, "le-store-certbot@https://github.com/mozilla-iot/le-store-certbot":
+le-store-certbot@^2.0.3, "le-store-certbot@https://github.com/mozilla-iot/le-store-certbot/tarball/master":
   version "2.0.5"
-  resolved "https://github.com/mozilla-iot/le-store-certbot#0df0a16d655e30429d5d08522bae70da5f2d58f8"
+  resolved "https://github.com/mozilla-iot/le-store-certbot/tarball/master#67da42eefbb2cf1ed451e989c467019f2ef374fd"
   dependencies:
     bluebird "^3.4.1"
     mkdirp "^0.5.1"
@@ -4296,9 +4296,9 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-pyconf@^1.1.2, "pyconf@https://github.com/mozilla-iot/node-config-python":
+pyconf@^1.1.2, "pyconf@https://github.com/mozilla-iot/node-config-python/tarball/master":
   version "1.1.2"
-  resolved "https://github.com/mozilla-iot/node-config-python#9d334161bca5bb49958d9b479b7e349d2503c24a"
+  resolved "https://github.com/mozilla-iot/node-config-python/tarball/master#4110e761fd68d4180d3394c27c9f5871ca176b5c"
   dependencies:
     safe-replace "^1.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,9 +4296,9 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-pyconf@^1.1.2:
+pyconf@^1.1.2, "pyconf@https://github.com/mozilla-iot/node-config-python":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/pyconf/-/pyconf-1.1.2.tgz#61a7aa299ff6ee57b8c687ad355a55d2e7a86a6b"
+  resolved "https://github.com/mozilla-iot/node-config-python#9d334161bca5bb49958d9b479b7e349d2503c24a"
   dependencies:
     safe-replace "^1.0.2"
 


### PR DESCRIPTION
The upstream version writes out invalid certbot renewal configs. Switch to the fork so we can fix that.