### PR TITLE
Write certbot configs to filesystem for later use.

### DIFF
--- a/src/controllers/settings_controller.js
+++ b/src/controllers/settings_controller.js
@@ -80,9 +80,10 @@ SettingsController.post('/subscribe', function (request, response) {
     // function to automatically agree and accept the ToS
     function leAgree(opts, agreeCb) { agreeCb(null, opts.tosUrl); }
     let leStore = require('le-store-certbot').create({
-        configDir: null,
-        debug: true,
-        logsDir: null
+        configDir: '~/mozilla-iot/etc',
+        logsDir: '~/mozilla-iot/var/log',
+        workDir: '~/mozilla-iot/var/lib',
+        debug: true
     });
     let le = greenlock.create({
         server: greenlock.productionServerUrl,


### PR DESCRIPTION
These need to be in the filesystem in a proper layout to allow `certbot` to renew certificates.