### PR TITLE
Simplify manual renewal script.

### DIFF
--- a/tools/manual-renew-certs.sh
+++ b/tools/manual-renew-certs.sh
@@ -16,6 +16,8 @@ abort() {
         kill -15 "${server_pid}" >/dev/null 2>/dev/null
     rm -rf "${temp_dir}"
 
+    systemctl start mozilla-iot-gateway.service
+
     echo -e "$1"
     exit 1
 }
@@ -24,12 +26,25 @@ if [ $(id -u) -ne 0 ]; then
     abort "This script must be run as root!"
 fi
 
-domain="$1"
-email="$2"
-
-if [ -z "$domain" -o -z "$email" ]; then
+email="$1"
+if [ -z "$email" ]; then
     prog=$(basename $(readlink -f "$0"))
-    abort "Usage:\n\t$prog DOMAIN EMAIL"
+    abort "Usage:\n\t$prog EMAIL"
+fi
+
+if [ ! -f "${moziot_dir}/gateway/tunneltoken" ]; then
+    abort "Could not read ${moziot_dir}/gateway/tunneltoken"
+fi
+
+domain="$(grep -oP '"name":".*?"' "${moziot_dir}/gateway/tunneltoken" | \
+          cut -d: -f2 | \
+          sed 's/"//g').mozilla-iot.org"
+token="$(grep -oP '"token":".*?"' "${moziot_dir}/gateway/tunneltoken" | \
+         cut -d: -f2 | \
+         sed 's/"//g')"
+
+if [ "${domain}" = ".mozilla-iot.org" -o -z "${token}" ]; then
+    abort "Could not determine domain or token."
 fi
 
 if [ -z "$(which certbot)" ]; then
@@ -65,7 +80,7 @@ openssl req \
     -keyout privkey.pem \
     -out cert.pem \
     -days 365 \
-    -subj "/C=US/ST=CA/L=Mountain View/O=Mozilla/CN=${domain}/emailAddress=${email}" \
+    -subj "/C=US/ST=CA/L=Mountain View/O=Mozilla/CN=${domain}/emailAddress=${moziot_email}" \
     -nodes >/dev/null 2>&1
 
 python2 server.py >/dev/null 2>&1 &
@@ -80,36 +95,19 @@ echo "Starting PageKite."
     --daemonize \
     --pidfile="${pagekite_pidfile}" || abort "Failed to start PageKite."
 
-echo "Verifying domain."
+echo "Verifying domain and renewing certificate for: ${domain}"
 certbot certonly \
     --webroot \
     --webroot-path "${temp_dir}" \
     --preferred-challenges=http \
     -d "${domain}" \
+    --force-renewal \
     --config-dir "${moziot_dir}/etc" \
     --work-dir "${moziot_dir}/var/lib" \
     --logs-dir "${moziot_dir}/var/log" \
     --non-interactive \
     --agree-tos \
-    --email "${email}" || abort "Failed to verify."
-
-echo "Renewing certificate."
-certbot renew \
-    --config-dir "${moziot_dir}/etc" \
-    --work-dir "${moziot_dir}/var/lib" \
-    --logs-dir "${moziot_dir}/var/log" \
-    --cert-path "${cert}" \
-    --force-renewal \
-    --non-interactive || abort "Failed to renew."
-
-echo "Updating certificate's email address."
-certbot register \
-    --config-dir "${moziot_dir}/etc" \
-    --work-dir "${moziot_dir}/var/lib" \
-    --logs-dir "${moziot_dir}/var/log" \
-    --update-registration \
-    --email "${moziot_email}" \
-    --non-interactive || abort "Failed to change email."
+    --email "${moziot_email}" || abort "Failed to verify and renew."
 
 chown -R pi:pi "${moziot_dir}/etc" "${moziot_dir}/var"
 
@@ -130,9 +128,6 @@ cp "${moziot_dir}/etc/live/${domain}/chain.pem" \
     "${moziot_dir}/gateway/chain.pem"
 
 echo "Registering domain with server."
-token="$(egrep -o '"token":".*?"' "${moziot_dir}/gateway/tunneltoken" | \
-         cut -d: -f2 | \
-         sed 's/"//g')"
 curl "http://api.mozilla-iot.org/setemail" \
     -s -G \
     --data-urlencode "token=${token}" \


### PR DESCRIPTION
As it turns out, the second and third certbot commands were not necessary at all. Also, we can just get the domain name from the tunneltoken file instead of asking for it.