### PR TITLE
Fixes #397 - allow scanChannels to be overridden via config

### DIFF
--- a/src/addons/zigbee-adapter/package.json
+++ b/src/addons/zigbee-adapter/package.json
@@ -25,6 +25,9 @@
     },
     "enabled": true,
     "plugin": true,
-    "exec": "node ./src/addon-loader.js zigbee-adapter"
+    "exec": "node ./src/addon-loader.js zigbee-adapter",
+    "config": {
+      "scanChannels": "0x1ffe"
+    }
   }
 }

--- a/src/addons/zigbee-adapter/zb-at.js
+++ b/src/addons/zigbee-adapter/zb-at.js
@@ -177,6 +177,10 @@ atBuilder[ac.NODE_JOIN_TIME] = function(frame, builder) {
   builder.appendUInt8(frame.nodeJoinTime);
 };
 
+atBuilder[ac.SCAN_CHANNELS] = function(frame, builder) {
+  builder.appendUInt16BE(frame.scanChannels);
+};
+
 atBuilder[ac.ZIGBEE_STACK_PROFILE] = function(frame, builder) {
   builder.appendUInt8(frame.zigBeeStackProfile);
 };


### PR DESCRIPTION
This allows the scanChannels to be overridden to force a
particular ZigBee operating channel to be used.