### PR TITLE
Add support for dimmable zigbee lights

### DIFF
--- a/src/addon-loader.js
+++ b/src/addon-loader.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var config = require('config');
+const Constants = require('./constants');
 const GetOpt = require('node-getopt');
 const PluginClient = require('./addons/plugin/plugin-client');
 const fs = require('fs');
@@ -74,8 +75,9 @@ async function loadAddon(packageName, verbose) {
       addonLoader(addonManagerProxy, newSettings, errorCallback);
       resolve();
     }).catch(e => {
+      console.error(e);
       const err =
-        `Failed to register package: ${manifest.name} with gateway\n${e}`;
+        `Failed to register package: ${manifest.name} with gateway`;
       reject(err);
     });
   });
@@ -89,6 +91,13 @@ const dynamicRequire = (() => {
   }
   return require;
 })();
+
+// Get some decent error messages for unhandled rejections. This is
+// often just errors in the code.
+process.on('unhandledRejection', (reason) => {
+  console.log('Unhandled Rejection');
+  console.error(reason);
+});
 
 // Command line arguments
 const getopt = new GetOpt([
@@ -104,16 +113,16 @@ if (opt.options.verbose) {
 
 if (opt.options.help) {
   getopt.showHelp();
-  process.exit(1);
+  process.exit(Constants.DONT_RESTART_EXIT_CODE);
 }
 
 if (opt.argv.length != 1) {
   console.error('Expecting a single package to load');
-  process.exit(1);
+  process.exit(Constants.DONT_RESTART_EXIT_CODE);
 }
 var packageName = opt.argv[0];
 
 loadAddon(packageName, opt.verbose).catch(err => {
   console.error(err);
-  process.exit(1);
+  process.exit(Constants.DONT_RESTART_EXIT_CODE);
 });

--- a/src/addons-test/mock-adapter/mock-adapter.js
+++ b/src/addons-test/mock-adapter/mock-adapter.js
@@ -14,7 +14,7 @@ var Property = require('../../addons/property');
 
 class MockProperty extends Property {
   constructor(device, name, propertyDescription) {
-    super(device, name, propertyDescription.type);
+    super(device, name, propertyDescription);
     this.unit = propertyDescription.unit;
     this.description = propertyDescription.description;
     this.setCachedValue(propertyDescription.value);

--- a/src/addons/device.js
+++ b/src/addons/device.js
@@ -96,6 +96,10 @@ class Device {
     });
   }
 
+  hasProperty(propertyName) {
+    return this.properties.has(propertyName);
+  }
+
   notifyPropertyChanged(property) {
     this.adapter.manager.emit(Constants.PROPERTY_CHANGED, property);
   }

--- a/src/addons/plugin/addon-manager-proxy.js
+++ b/src/addons/plugin/addon-manager-proxy.js
@@ -221,8 +221,7 @@ class AddonManagerProxy extends EventEmitter {
     this.pluginClient.sendNotification(Constants.PROPERTY_CHANGED, {
       adapterId: property.device.adapter.id,
       deviceId: property.device.id,
-      propertyName: property.name,
-      propertyValue: property.value,
+      property: property.asDict()
     });
   }
 }

--- a/src/addons/plugin/device-proxy.js
+++ b/src/addons/plugin/device-proxy.js
@@ -30,7 +30,8 @@ class DeviceProxy extends Device {
     // Copy over any extra device fields which might be useful for debugging.
     this.deviceDict = {};
     for (let field in deviceDict) {
-      if (field in ['id', 'name', 'type', 'properties', 'actions', 'events']) {
+      if (['id', 'name', 'type', 'properties', 'actions', 'events']
+            .includes(field)) {
         continue;
       }
       this.deviceDict[field] = deviceDict[field];

--- a/src/addons/plugin/device-proxy.js
+++ b/src/addons/plugin/device-proxy.js
@@ -27,7 +27,20 @@ class DeviceProxy extends Device {
       this.properties.set(propertyName, propertyProxy);
     }
 
+    // Copy over any extra device fields which might be useful for debugging.
+    this.deviceDict = {};
+    for (let field in deviceDict) {
+      if (field in ['id', 'name', 'type', 'properties', 'actions', 'events']) {
+        continue;
+      }
+      this.deviceDict[field] = deviceDict[field];
+    }
+
     //TODO: Add support for actions once we know what they look like.
+  }
+
+  asDict() {
+    return Object.assign({}, this.deviceDict, super.asDict());
   }
 }
 

--- a/src/addons/plugin/property-proxy.js
+++ b/src/addons/plugin/property-proxy.js
@@ -15,18 +15,16 @@ const Property = require('../property');
 
 class PropertyProxy extends Property {
   constructor(device, propertyName, propertyDict) {
-    super(device, propertyName, propertyDict.type);
-
-    if (propertyDict.description) {
-      this.description = propertyDict.description;
-    }
-    if (propertyDict.unit) {
-      this.description = propertyDict.unit;
-    }
+    super(device, propertyName, propertyDict);
 
     this.value = propertyDict.value;
 
     this.propertyChangedPromises = [];
+    this.propertyDict = {};
+  }
+
+  asDict() {
+    return Object.assign({}, this.propertyDict, super.asDict());
   }
 
   /**
@@ -45,11 +43,12 @@ class PropertyProxy extends Property {
    * Called whenever a property changed notification is received
    * from the adapter.
    */
-  doPropertyChanged(value) {
-    this.setCachedValue(value);
+  doPropertyChanged(propertyDict) {
+    this.propertyDict = Object.assign({}, propertyDict);
+    this.setCachedValue(propertyDict.value);
     while (this.propertyChangedPromises.length > 0) {
       var deferredChange = this.propertyChangedPromises.pop();
-      deferredChange.resolve(value);
+      deferredChange.resolve(propertyDict.value);
     }
   }
 

--- a/src/addons/property.js
+++ b/src/addons/property.js
@@ -10,16 +10,29 @@
 
 'use strict';
 
+const assert = require('assert');
+
+const DESCR_FIELDS = ['type', 'unit', 'description', 'min', 'max'];
+function copyDescrFieldsInto(target, source) {
+  for (let field of DESCR_FIELDS) {
+    if (source.hasOwnProperty(field)) {
+      target[field] = source[field];
+    }
+  }
+}
+
 class Property {
-  constructor(device, name, type) {
+  constructor(device, name, propertyDescr) {
+    // The propertyDescr argument used to be the 'type' string, so we add an
+    // assertion here to notify anybody who has an older plugin.
+
+    assert.equal(typeof(propertyDescr), 'object',
+                 'Please update plugin to use property description.');
+
     this.device = device;
     this.name = name;
-    this.type = type;
 
-    // Other optional attributes that an instance of this class can have.
-    // this.unit
-    // this.description
-    // this.value
+    copyDescrFieldsInto(this, propertyDescr);
   }
 
   /**
@@ -29,15 +42,9 @@ class Property {
   asDict() {
     var prop = {
       name: this.name,
-      type: this.type,
       value: this.value,
     };
-    if (this.description) {
-      prop.description = this.description;
-    }
-    if (this.unit) {
-      prop.unit = this.unit;
-    }
+    copyDescrFieldsInto(prop, this);
     return prop;
   }
 
@@ -47,13 +54,7 @@ class Property {
    */
   asPropertyDescription() {
     var description = {};
-    description.type = this.type;
-    if (this.description) {
-      description.description = this.description;
-    }
-    if (this.unit) {
-      description.unit = this.unit;
-    }
+    copyDescrFieldsInto(description, this);
     return description;
   }
 

--- a/src/addons/zigbee-adapter/index.js
+++ b/src/addons/zigbee-adapter/index.js
@@ -1,6 +1,6 @@
 /**
  *
- * index.js - Loads the ZigBee adapter.
+ * index.js - Loads the Zigbee adapter.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,6 +10,6 @@
 
 'use strict';
 
-var loadZigBeeAdapters = require('./zb-adapter');
+var loadZigbeeAdapters = require('./zb-adapter');
 
-module.exports = loadZigBeeAdapters;
+module.exports = loadZigbeeAdapters;

--- a/src/addons/zigbee-adapter/package.json
+++ b/src/addons/zigbee-adapter/package.json
@@ -27,7 +27,8 @@
     "plugin": true,
     "exec": "node ./src/addon-loader.js zigbee-adapter",
     "config": {
-      "scanChannels": "0x1ffe"
+      "scanChannels": "0x1ffe",
+      "discoverAttributes": false
     }
   }
 }

--- a/src/addons/zigbee-adapter/zb-adapter.js
+++ b/src/addons/zigbee-adapter/zb-adapter.js
@@ -1,6 +1,6 @@
 /**
  *
- * ZigBeeAdapter - Adapter which manages ZigBee devices.
+ * ZigbeeAdapter - Adapter which manages Zigbee devices.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,7 +10,7 @@
 'use strict';
 
 var Adapter = require('../adapter');
-var ZigBeeNode = require('./zb-node');
+var ZigbeeNode = require('./zb-node');
 var SerialPort = require('serialport');
 var xbeeApi = require('xbee-api');
 var at = require('./zb-at');
@@ -72,9 +72,9 @@ function FUNC(ths, func, args) {
   return new Command(EXEC_FUNC, [ths, func, args]);
 }
 
-class ZigBeeAdapter extends Adapter {
+class ZigbeeAdapter extends Adapter {
   constructor(addonManager, manifest, port) {
-    // The ZigBee adapter supports multiple dongles and
+    // The Zigbee adapter supports multiple dongles and
     // will create an adapter object for each dongle.
     // We don't know the actual adapter id until we
     // retrieve the serial number from the dongle. So we
@@ -149,7 +149,7 @@ class ZigBeeAdapter extends Adapter {
         console.error('SerialPort open err =', err);
       }
 
-      // Hook up the ZigBee raw parser.
+      // Hook up the Zigbee raw parser.
       this.serialport.on('data', chunk => {
         this.xb.parseRaw(chunk);
       });
@@ -189,7 +189,7 @@ class ZigBeeAdapter extends Adapter {
     // Use this opertunity to create the node for the Coordinator.
 
     var coordinator = this.nodes[this.serialNumber] =
-      new ZigBeeNode(this, this.serialNumber, this.networkAddr16);
+      new ZigbeeNode(this, this.serialNumber, this.networkAddr16);
 
     // Go find out what devices are on the network.
     this.queueCommands(
@@ -261,7 +261,7 @@ class ZigBeeAdapter extends Adapter {
       // We're going to change something, so we might as well set the link
       // key, since it's write only and we can't tell if its been set before.
       configCommands.push(this.AT(AT_CMD.LINK_KEY,
-                                  {linkKey: 'ZigBeeAlliance09'}));
+                                  {linkKey: 'ZigbeeAlliance09'}));
       configCommands.push(this.AT(AT_CMD.WRITE_PARAMETERS));
 
       // TODO: It sends a modem status, but only the first time after the
@@ -516,8 +516,8 @@ class ZigBeeAdapter extends Adapter {
         this.dumpFrame('Rcvd:', frame);
       }
       var clusterId = parseInt(frame.clusterId, 16);
-      if (clusterId in ZigBeeAdapter.zdoClusterHandler) {
-        ZigBeeAdapter.zdoClusterHandler[clusterId].call(this, frame);
+      if (clusterId in ZigbeeAdapter.zdoClusterHandler) {
+        ZigbeeAdapter.zdoClusterHandler[clusterId].call(this, frame);
       }
     } else if (this.isZhaFrame(frame)) {
       zcl.parse(frame.data, parseInt(frame.clusterId, 16), (error, data) => {
@@ -571,12 +571,12 @@ class ZigBeeAdapter extends Adapter {
   handleAtResponse(frame) {
     if (frame.commandData.length) {
       this.at.parseFrame(frame);
-      if (frame.command in ZigBeeAdapter.atCommandMap) {
-        var varName = ZigBeeAdapter.atCommandMap[frame.command];
+      if (frame.command in ZigbeeAdapter.atCommandMap) {
+        var varName = ZigbeeAdapter.atCommandMap[frame.command];
         this[varName] = frame[varName];
       } else {
-        if (frame.command in ZigBeeAdapter.atResponseHandler) {
-          ZigBeeAdapter.atResponseHandler[frame.command].call(this, frame);
+        if (frame.command in ZigbeeAdapter.atResponseHandler) {
+          ZigbeeAdapter.atResponseHandler[frame.command].call(this, frame);
         }
       }
     }
@@ -606,7 +606,7 @@ class ZigBeeAdapter extends Adapter {
     } else {
 
       node = this.nodes[frame.zdoAddr64] =
-        new ZigBeeNode(this, frame.zdoAddr64, frame.zdoAddr16);
+        new ZigbeeNode(this, frame.zdoAddr64, frame.zdoAddr16);
     }
     if (this.isPairing) {
       this.cancelPairing();
@@ -735,7 +735,7 @@ class ZigBeeAdapter extends Adapter {
     var node = this.nodes[frame.remote64];
     if (!node) {
       node = this.nodes[frame.remote64] =
-        new ZigBeeNode(this, frame.remote64, frame.remote16);
+        new ZigbeeNode(this, frame.remote64, frame.remote16);
     }
 
     for (var i = 0; i < frame.numEntriesThisResponse; i++) {
@@ -748,7 +748,7 @@ class ZigBeeAdapter extends Adapter {
       var neighborNode = this.nodes[neighbor.addr64];
       if (!neighborNode) {
         this.nodes[neighbor.addr64] =
-          new ZigBeeNode(this, neighbor.addr64, neighbor.addr16);
+          new ZigbeeNode(this, neighbor.addr64, neighbor.addr16);
         neighborNode = this.nodes[neighbor.addr64];
       }
       if (neighborNode.addr16 == 'fffe') {
@@ -1119,7 +1119,7 @@ class ZigBeeAdapter extends Adapter {
 
   handleDeviceAdded(node) {
     if (this.debugFlow) {
-      console.log('ZigBeeAdapter: handleDeviceAdded: ', node.addr64);
+      console.log('ZigbeeAdapter: handleDeviceAdded: ', node.addr64);
     }
     if (node.isCoordinator) {
       node.name = node.defaultName;
@@ -1134,7 +1134,7 @@ class ZigBeeAdapter extends Adapter {
       this.dumpFrame('Rcvd (before parsing):', frame);
     }
     this.frameDumped = false;
-    var frameHandler = ZigBeeAdapter.frameHandler[frame.type];
+    var frameHandler = ZigbeeAdapter.frameHandler[frame.type];
     if (frameHandler) {
       frameHandler.call(this, frame);
     }
@@ -1280,7 +1280,7 @@ class ZigBeeAdapter extends Adapter {
   }
 }
 
-var acm = ZigBeeAdapter.atCommandMap = {};
+var acm = ZigbeeAdapter.atCommandMap = {};
 acm[AT_CMD.API_OPTIONS] = 'apiOptions';
 acm[AT_CMD.CONFIGURED_64_BIT_PAN_ID] = 'configuredPanId64';
 acm[AT_CMD.DEVICE_TYPE_IDENTIFIER] = 'deviceTypeIdentifier';
@@ -1296,35 +1296,35 @@ acm[AT_CMD.OPERATING_CHANNEL] = 'operatingChannel';
 acm[AT_CMD.SCAN_CHANNELS] = 'scanChannels';
 acm[AT_CMD.ZIGBEE_STACK_PROFILE] = 'zigBeeStackProfile';
 
-var arh = ZigBeeAdapter.atResponseHandler = {};
+var arh = ZigbeeAdapter.atResponseHandler = {};
 arh[AT_CMD.SERIAL_NUMBER_HIGH] =
-  ZigBeeAdapter.prototype.handleAtSerialNumberHigh;
+  ZigbeeAdapter.prototype.handleAtSerialNumberHigh;
 arh[AT_CMD.SERIAL_NUMBER_LOW] =
-  ZigBeeAdapter.prototype.handleAtSerialNumberLow;
+  ZigbeeAdapter.prototype.handleAtSerialNumberLow;
 
-var fh = ZigBeeAdapter.frameHandler = {};
+var fh = ZigbeeAdapter.frameHandler = {};
 fh[C.FRAME_TYPE.AT_COMMAND_RESPONSE] =
-  ZigBeeAdapter.prototype.handleAtResponse;
+  ZigbeeAdapter.prototype.handleAtResponse;
 fh[C.FRAME_TYPE.ZIGBEE_EXPLICIT_RX] =
-  ZigBeeAdapter.prototype.handleExplicitRx;
+  ZigbeeAdapter.prototype.handleExplicitRx;
 fh[C.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS] =
-  ZigBeeAdapter.prototype.handleTransmitStatus;
+  ZigbeeAdapter.prototype.handleTransmitStatus;
 fh[C.FRAME_TYPE.ROUTE_RECORD] =
-  ZigBeeAdapter.prototype.handleRouteRecord;
+  ZigbeeAdapter.prototype.handleRouteRecord;
 
-var zch = ZigBeeAdapter.zdoClusterHandler = {};
+var zch = ZigbeeAdapter.zdoClusterHandler = {};
 zch[zdo.CLUSTER_ID.ACTIVE_ENDPOINTS_RESPONSE] =
-  ZigBeeAdapter.prototype.handleActiveEndpointsResponse;
+  ZigbeeAdapter.prototype.handleActiveEndpointsResponse;
 zch[zdo.CLUSTER_ID.MANAGEMENT_LEAVE_RESPONSE] =
-  ZigBeeAdapter.prototype.handleManagementLeaveResponse;
+  ZigbeeAdapter.prototype.handleManagementLeaveResponse;
 zch[zdo.CLUSTER_ID.MANAGEMENT_LQI_RESPONSE] =
-  ZigBeeAdapter.prototype.handleManagementLqiResponse;
+  ZigbeeAdapter.prototype.handleManagementLqiResponse;
 zch[zdo.CLUSTER_ID.MANAGEMENT_RTG_RESPONSE] =
-  ZigBeeAdapter.prototype.handleManagementRtgResponse;
+  ZigbeeAdapter.prototype.handleManagementRtgResponse;
 zch[zdo.CLUSTER_ID.SIMPLE_DESCRIPTOR_RESPONSE] =
-  ZigBeeAdapter.prototype.handleSimpleDescriptorResponse;
+  ZigbeeAdapter.prototype.handleSimpleDescriptorResponse;
 zch[zdo.CLUSTER_ID.END_DEVICE_ANNOUNCEMENT] =
-  ZigBeeAdapter.prototype.handleEndDeviceAnnouncement;
+  ZigbeeAdapter.prototype.handleEndDeviceAnnouncement;
 
 function isDigiPort(port) {
   // Note that 0403:6001 is the default FTDI VID:PID, so we need to further
@@ -1358,21 +1358,21 @@ function findDigiPorts() {
   });
 }
 
-function loadZigBeeAdapters(addonManager, manifest, errorCallback) {
+function loadZigbeeAdapters(addonManager, manifest, errorCallback) {
   findDigiPorts().then((digiPorts) => {
     for (var port of digiPorts) {
       // Under OSX, SerialPort.list returns the /dev/tty.usbXXX instead
       // /dev/cu.usbXXX. tty.usbXXX requires DCD to be asserted which
-      // isn't necessarily the case for ZigBee dongles. The cu.usbXXX
+      // isn't necessarily the case for Zigbee dongles. The cu.usbXXX
       // doesn't care about DCD.
       if (port.comName.startsWith('/dev/tty.usb')) {
         port.comName = port.comName.replace('/dev/tty', '/dev/cu');
       }
-      new ZigBeeAdapter(addonManager, manifest, port);
+      new ZigbeeAdapter(addonManager, manifest, port);
     }
   }, (error) => {
     errorCallback(manifest.name, error);
   });
 }
 
-module.exports = loadZigBeeAdapters;
+module.exports = loadZigbeeAdapters;

--- a/src/addons/zigbee-adapter/zb-adapter.js
+++ b/src/addons/zigbee-adapter/zb-adapter.js
@@ -261,7 +261,7 @@ class ZigbeeAdapter extends Adapter {
       // We're going to change something, so we might as well set the link
       // key, since it's write only and we can't tell if its been set before.
       configCommands.push(this.AT(AT_CMD.LINK_KEY,
-                                  {linkKey: 'ZigbeeAlliance09'}));
+                                  {linkKey: 'ZigBeeAlliance09'}));
       configCommands.push(this.AT(AT_CMD.WRITE_PARAMETERS));
 
       // TODO: It sends a modem status, but only the first time after the

--- a/src/addons/zigbee-adapter/zb-at.js
+++ b/src/addons/zigbee-adapter/zb-at.js
@@ -77,7 +77,7 @@ ac.WRITE_PARAMETERS = 'WR';
 ac[ac.WRITE_PARAMETERS] = 'Write Parameters (WR)';
 
 ac.ZIGBEE_STACK_PROFILE = 'ZS';
-ac[ac.ZIGBEE_STACK_PROFILE] = 'ZigBee Stack Profile (ZS)';
+ac[ac.ZIGBEE_STACK_PROFILE] = 'Zigbee Stack Profile (ZS)';
 
 var atBuilder = module.exports.atBuilder = {};
 var atParser = module.exports.atParser = {};

--- a/src/addons/zigbee-adapter/zb-classifier.js
+++ b/src/addons/zigbee-adapter/zb-classifier.js
@@ -10,20 +10,71 @@
 
 'use strict';
 
-var zclId = require('zcl-id');
-var utils = require('../utils');
-var ZigBeeProperty = require('./zb-property');
+const zclId = require('zcl-id');
+const utils = require('../utils');
+const ZigBeeProperty = require('./zb-property');
 
 const ZHA_PROFILE_ID = zclId.profile('HA').value;
 const ZHA_PROFILE_ID_HEX = utils.hexStr(ZHA_PROFILE_ID, 4);
 const CLUSTER_ID_GENONOFF = zclId.cluster('genOnOff').value;
 const CLUSTER_ID_GENONOFF_HEX = utils.hexStr(CLUSTER_ID_GENONOFF, 4);
+const CLUSTER_ID_GENLEVELCTRL = zclId.cluster('genLevelCtrl').value;
+const CLUSTER_ID_GENLEVELCTRL_HEX = utils.hexStr(CLUSTER_ID_GENLEVELCTRL, 4);
 
 const THING_TYPE_ON_OFF_SWITCH = 'onOffSwitch';
+const THING_TYPE_MULTI_LEVEL_SWITCH = 'multiLevelSwitch';
 
 class ZigBeeClassifier {
 
   constructor() {
+  }
+
+  addLevelProperty(node, endpoint) {
+    this.addProperty(
+      node,                           // device
+      'level',                        // name
+      {                               // property description
+        type: 'number',
+        unit: '%',
+        min: 0,
+        max: 100,
+      },
+      ZHA_PROFILE_ID,                 // profileId
+      endpoint,                       // endpoint
+      CLUSTER_ID_GENLEVELCTRL,        // clusterId
+      'currentLevel',                 // attr
+      'setLevelValue',                // setAttrFromValue
+      'parseLevelAttr'                // parseValueFromAttr
+    );
+  }
+
+  addOnProperty(node, endpoint) {
+    this.addProperty(
+      node,                           // device
+      'on',                           // name
+      {                               // property description
+        type: 'boolean',
+      },
+      ZHA_PROFILE_ID,                 // profileId
+      endpoint,                       // endpoint
+      CLUSTER_ID_GENONOFF,            // clusterId
+      'onOff',                        // attr
+      'setOnOffValue',                // setAttrFromValue
+      'parseOnOffAttr'                // parseValueFromAttr
+    );
+  }
+
+  addProperty(node, name, descr, profileId, endpoint, clusterId,
+              attr, setAttrFromValue, parseValueFromAttr) {
+    let property =  new ZigBeeProperty(node, name, descr, profileId,
+                                       endpoint, clusterId, attr,
+                                       setAttrFromValue, parseValueFromAttr);
+    node.properties.set(name, property);
+    node.sendFrames([
+      node.makeBindFrame(property),
+      node.makeConfigReportFrame(property),
+      node.makeReadAttributeFrame(property),
+    ]);
   }
 
   findZhaEndpointWithInputClusterIdHex(node, clusterIdHex) {
@@ -37,16 +88,36 @@ class ZigBeeClassifier {
     }
   }
 
-  classify(node) {
-    if (!node.isCoordinator) {
-      var endpointNum;
-      endpointNum =
-        this.findZhaEndpointWithInputClusterIdHex(node,
-                                                  CLUSTER_ID_GENONOFF_HEX);
-      if (endpointNum) {
-        this.initOnOffSwitch(node, endpointNum);
-      }
+  // internal function allows us to use early returns.
+  classifyInternal(node) {
+    let endpoint;
+
+    endpoint =
+      this.findZhaEndpointWithInputClusterIdHex(node,
+                                                CLUSTER_ID_GENLEVELCTRL_HEX);
+    if (endpoint) {
+      this.initMultiLevelSwitch(node, endpoint);
+      return;
     }
+
+    endpoint =
+      this.findZhaEndpointWithInputClusterIdHex(node,
+                                                CLUSTER_ID_GENONOFF_HEX);
+    if (endpoint) {
+      this.initOnOffSwitch(node, endpoint);
+      return;
+    }
+  }
+
+  classify(node) {
+    if (node.isCoordinator) {
+      return;
+    }
+
+    this.classifyInternal(node);
+
+    // Now that we know the type, set the default name.
+    node.defaultName = node.id + '-' + node.type;
     if (!node.name) {
       node.name = node.defaultName;
     }
@@ -54,24 +125,13 @@ class ZigBeeClassifier {
 
   initOnOffSwitch(node, endpointNum) {
     node.type = THING_TYPE_ON_OFF_SWITCH;
-    var property = new ZigBeeProperty(
-      node,                           // device
-      'on',                           // name
-      'boolean',                      // type
-      ZHA_PROFILE_ID,                 // profileId
-      endpointNum,                    // endpoint
-      CLUSTER_ID_GENONOFF,            // clusterId
-      { true: 'on', false: 'off' },   // cmd
-      'onOff'                         // attr
-    );
+    this.addOnProperty(node, endpointNum);
+  }
 
-    node.properties.set('on', property);
-    node.defaultName = node.id + '-' + node.type;
-    node.sendFrames([
-      node.makeBindFrame(property),
-      node.makeConfigReportFrame(property),
-      node.makeReadAttributeFrame(property)
-    ]);
+  initMultiLevelSwitch(node, endpointNum) {
+    node.type = THING_TYPE_MULTI_LEVEL_SWITCH;
+    this.addOnProperty(node, endpointNum);
+    this.addLevelProperty(node, endpointNum);
   }
 }
 

--- a/src/addons/zigbee-adapter/zb-classifier.js
+++ b/src/addons/zigbee-adapter/zb-classifier.js
@@ -1,6 +1,6 @@
 /**
  *
- * ZigBeeClassifier - Determines properties from ZigBee clusters.
+ * ZigbeeClassifier - Determines properties from Zigbee clusters.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,7 +12,7 @@
 
 const zclId = require('zcl-id');
 const utils = require('../utils');
-const ZigBeeProperty = require('./zb-property');
+const ZigbeeProperty = require('./zb-property');
 
 const ZHA_PROFILE_ID = zclId.profile('HA').value;
 const ZHA_PROFILE_ID_HEX = utils.hexStr(ZHA_PROFILE_ID, 4);
@@ -24,7 +24,7 @@ const CLUSTER_ID_GENLEVELCTRL_HEX = utils.hexStr(CLUSTER_ID_GENLEVELCTRL, 4);
 const THING_TYPE_ON_OFF_SWITCH = 'onOffSwitch';
 const THING_TYPE_MULTI_LEVEL_SWITCH = 'multiLevelSwitch';
 
-class ZigBeeClassifier {
+class ZigbeeClassifier {
 
   constructor() {
   }
@@ -66,7 +66,7 @@ class ZigBeeClassifier {
 
   addProperty(node, name, descr, profileId, endpoint, clusterId,
               attr, setAttrFromValue, parseValueFromAttr) {
-    let property =  new ZigBeeProperty(node, name, descr, profileId,
+    let property =  new ZigbeeProperty(node, name, descr, profileId,
                                        endpoint, clusterId, attr,
                                        setAttrFromValue, parseValueFromAttr);
     node.properties.set(name, property);
@@ -135,4 +135,4 @@ class ZigBeeClassifier {
   }
 }
 
-module.exports = new ZigBeeClassifier();
+module.exports = new ZigbeeClassifier();

--- a/src/addons/zigbee-adapter/zb-node.js
+++ b/src/addons/zigbee-adapter/zb-node.js
@@ -1,6 +1,6 @@
 /**
  *
- * ZigBeeDevice - represents a device on the ZigBee network
+ * ZigbeeDevice - represents a device on the Zigbee network
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -18,10 +18,10 @@ var zdo = require('./zb-zdo');
 
 var C = xbeeApi.constants;
 
-class ZigBeeNode extends Device {
+class ZigbeeNode extends Device {
 
   constructor(adapter, id64, id16) {
-    // Our id is a Mac address on the ZigBee network. It's unique within
+    // Our id is a Mac address on the Zigbee network. It's unique within
     // the zigbee network, but might not be globally unique, so we prepend
     // with zb- to put it in a namespace.
     var deviceId = 'zb-' + id64;
@@ -321,4 +321,4 @@ class ZigBeeNode extends Device {
   }
 }
 
-module.exports = ZigBeeNode;
+module.exports = ZigbeeNode;

--- a/src/addons/zigbee-adapter/zb-property.js
+++ b/src/addons/zigbee-adapter/zb-property.js
@@ -73,22 +73,22 @@ class ZigBeeProperty extends Property {
    * a property value.
    *
    * @param attrEntry - An attribute entry from the zcl-packet library
-   *                    readRsp which will look something like this:
-   * { attrId: 0, status: 0, dataType: 32, attrData: 254 }
+   *    readRsp which will look something like this:
+   *    { attrId: 0, status: 0, dataType: 32, attrData: 254 }
    *
    *    attrId is a 16-bit attribute id.
    *    status is an 8-bit status indicating the success/failure of the read.
    *    dataType is an 8-bit field indicating the type of data.
    *    attrData contains the actual data.
    *
-   * The above fields can be examined symbolically using the zcl-id module:
+   *    The above fields can be examined symbolically using the zcl-id module:
    *    zclId.attr('genLevelCtrl', 0).key == 'currentLevel'
    *    zclId.status(0).key == 'success'
    *    zclId.dataType(32).key == 'uint8'
    *
    * @returns an array containing 2 entries. The first entry is the
-   *          property value, and the second entry is a printable version
-   * suitable for logging.
+   *    property value, and the second entry is a printable version
+   *    suitable for logging.
    */
 
   parseAttrEntry(attrEntry) {

--- a/src/addons/zigbee-adapter/zb-property.js
+++ b/src/addons/zigbee-adapter/zb-property.js
@@ -14,14 +14,42 @@ var Deferred = require('../deferred');
 var Property = require('../property');
 var utils = require('../utils');
 
+/**
+ * @function levelToPercent
+ *
+ * Converts a light level in the range 0-254 into a percentage using
+ * linear interpolation.
+ */
+function levelToPercent(level) {
+  if (level < 1) {
+    return 0;
+  }
+  return Math.min(level * 100 / 254, 100);
+}
+
+/**
+ * @function percentToLevel
+ *
+ * Inverse of the levelToPercent function. Takes a percentage in the range
+ * 0-100 and converts it into a level in the range 0-254.
+ */
+function percentToLevel(percent) {
+  if (percent < 0.1) {
+    return 0;
+  }
+  return Math.min(Math.round(percent * 254 / 100), 254);
+}
+
 class ZigBeeProperty extends Property {
-  constructor(device, name, type, profileId, endpoint, clusterId, cmd, attr) {
-    super(device, name, type);
+  constructor(device, name, propertyDescr, profileId, endpoint, clusterId, attr,
+              setAttrFromValue, parseValueFromAttr) {
+    super(device, name, propertyDescr);
 
     this.profileId = profileId;
     this.endpoint = endpoint;
     this.clusterId = clusterId;
-    this.cmd = cmd;
+    this.setAttrFromValue = Object.getPrototypeOf(this)[setAttrFromValue];
+    this.parseValueFromAttr = Object.getPrototypeOf(this)[parseValueFromAttr];
     this.attr = attr;
   }
 
@@ -30,10 +58,112 @@ class ZigBeeProperty extends Property {
     dict.profileId = this.profileId;
     dict.endpoint = this.endpoint;
     dict.clusterId = this.clusterId;
-    dict.cmd = this.cmd;
     dict.attr = this.attr;
     dict.value = this.value;
+    if (this.hasOwnProperty('level')) {
+      dict.level = this.level;
+    }
     return dict;
+  }
+
+  /**
+   * @method parseAttrEntry
+   *
+   * Parses the attribute data received via ZCL and converts it into
+   * a property value.
+   *
+   * @param attrEntry - An attribute entry from the zcl-packet library
+   *                    readRsp which will look something like this:
+   * { attrId: 0, status: 0, dataType: 32, attrData: 254 }
+   *
+   *    attrId is a 16-bit attribute id.
+   *    status is an 8-bit status indicating the success/failure of the read.
+   *    dataType is an 8-bit field indicating the type of data.
+   *    attrData contains the actual data.
+   *
+   * The above fields can be examined symbolically using the zcl-id module:
+   *    zclId.attr('genLevelCtrl', 0).key == 'currentLevel'
+   *    zclId.status(0).key == 'success'
+   *    zclId.dataType(32).key == 'uint8'
+   *
+   * @returns an array containing 2 entries. The first entry is the
+   *          property value, and the second entry is a printable version
+   * suitable for logging.
+   */
+
+  parseAttrEntry(attrEntry) {
+    return this.parseValueFromAttr(attrEntry);
+  }
+
+  /**
+   * @method parseLevelAttr
+   *
+   * Converts the ZCL 'currentLevel' attribute (a uint8) into
+   * a 'level' property (a percentage).
+   */
+  parseLevelAttr(attrEntry) {
+    this.level = attrEntry.attrData;
+    console.log('Setting this.level to', this.level);
+    let percent = levelToPercent(this.level);
+    return [
+      percent,
+      percent.toFixed(1) + '% (' + this.level + ')'
+    ];
+  }
+
+  /**
+   * @method parseOnOffAttr
+   *
+   * Converts the ZCL 'onOff' attribute (a boolean) into the 'on' property
+   * (a boolean).
+   */
+  parseOnOffAttr(attrEntry) {
+    let propertyValue = attrEntry.attrData != 0;
+    return [
+      propertyValue,
+      (propertyValue ? 'on' : 'off') + ' (' + attrEntry.attrData + ')'
+    ];
+  }
+
+  /**
+   * @method setLevelAttr
+   *
+   * Convert the 'level' property value (a percentage) into the ZCL
+   * 'moveToLevel' command along with a light level.
+   */
+  setLevelValue(propertyValue) {
+    // propertyValue is a percentage 0-100
+    if (this.hasOwnProperty('min') && propertyValue < this.min) {
+      propertyValue = this.min;
+    }
+    if (this.hasOwnProperty('max') && propertyValue > this.max) {
+      propertyValue = this.max;
+    }
+    this.level = percentToLevel(propertyValue);
+    return [{
+        frameCntl: {frameType: 1},
+        cmd: 'moveToLevel',
+        payload: [this.level],
+      },
+      'level: ' + this.level + ' (' + propertyValue.toFixed(1) + '%)'
+    ];
+  }
+
+  /**
+   * @method setOnOffAttr
+   *
+   * Converts the 'on' property value (a boolean) into the ZCL on or off
+   * command.
+   */
+  setOnOffValue(propertyValue) {
+    // propertyValue is a boolean
+    let attr = propertyValue ? 'on' : 'off';
+    return [{
+        frameCntl: {frameType: 1},
+        cmd: attr,
+      },
+      attr
+    ];
   }
 
   /**
@@ -51,28 +181,18 @@ class ZigBeeProperty extends Property {
 
     this.setCachedValue(value);
 
-    let cmd = this.cmd[value];
+    let [zclData, logData] = this.setAttrFromValue(value);
 
-    console.log('ZigBee: setProperty property:', this.name,
+    console.log('setProperty property:', this.name,
                 'for:', this.device.name,
                 'profileId:', utils.hexStr(this.profileId, 4),
                 'endpoint:', this.endpoint,
                 'clusterId:', utils.hexStr(this.clusterId, 4),
-                'cmd:', cmd,
+                'zcl:', logData,
                 'value:', value);
 
-    if (cmd === undefined) {
-      let err = 'ZigBee: unrecognized value: "' + value + '"';
-      console.error('ZigBee: unrecognized value: "' + value + '"');
-      deferredSet.reject(err);
-    } else {
-      this.device.sendZclFrameWaitExplicitRxResolve(
-        this,
-        {
-          frameCntl: { frameType: 1 },
-          cmd: cmd,
-        });
-    }
+    this.device.sendZclFrameWaitExplicitRxResolve(this, zclData);
+
     return deferredSet.promise;
   }
 }

--- a/src/addons/zigbee-adapter/zb-property.js
+++ b/src/addons/zigbee-adapter/zb-property.js
@@ -1,5 +1,5 @@
 /**
- * ZigBee Property.
+ * Zigbee Property.
  *
  * Object which decscribes a property, and its value.
  *
@@ -40,7 +40,7 @@ function percentToLevel(percent) {
   return Math.min(Math.round(percent * 254 / 100), 254);
 }
 
-class ZigBeeProperty extends Property {
+class ZigbeeProperty extends Property {
   constructor(device, name, propertyDescr, profileId, endpoint, clusterId, attr,
               setAttrFromValue, parseValueFromAttr) {
     super(device, name, propertyDescr);
@@ -197,4 +197,4 @@ class ZigBeeProperty extends Property {
   }
 }
 
-module.exports = ZigBeeProperty;
+module.exports = ZigbeeProperty;

--- a/src/addons/zigbee-adapter/zb-zdo.js
+++ b/src/addons/zigbee-adapter/zb-zdo.js
@@ -1,6 +1,6 @@
 /**
  *
- * zb-zdo - Frame builder/parser for the ZigBee ZDO layer
+ * zb-zdo - Frame builder/parser for the Zigbee ZDO layer
  *
  * This follows the pattern used for the xbee-api, and builds the
  * buffer needed for the frame.data used with the

--- a/src/addons/zwave-adapter/zwave-adapter.js
+++ b/src/addons/zwave-adapter/zwave-adapter.js
@@ -70,38 +70,38 @@ class ZWaveAdapter extends Adapter {
   }
 
   dump() {
-    console.log('ZWave:', this.oneLineSummary());
-    console.log('ZWave:', ZWaveNode.oneLineHeader(0));
-    console.log('ZWave:', ZWaveNode.oneLineHeader(1));
+    console.log(this.oneLineSummary());
+    console.log(ZWaveNode.oneLineHeader(0));
+    console.log(ZWaveNode.oneLineHeader(1));
     for (var nodeId in this.nodes) {
       let node = this.nodes[nodeId];
-      console.log('ZWave:', node.oneLineSummary());
+      console.log(node.oneLineSummary());
     }
-    console.log('ZWave:', '----');
+    console.log('----');
   }
 
   controllerCommand(nodeId, retVal, state, msg) {
-    console.log('ZWave: Controller Command feedback: %s node%d retVal:%d ' +
+    console.log('Controller Command feedback: %s node%d retVal:%d ' +
                 'state:%d', msg, nodeId, retVal, state);
 
 
   }
 
   driverReady(homeId) {
-    console.log('ZWave: Driver Ready: HomeId:', homeId.toString(16));
+    console.log('Driver Ready: HomeId:', homeId.toString(16));
     this.id = 'zwave-' + homeId.toString(16);
 
     this.manager.addAdapter(this);
   }
 
   driverFailed() {
-    console.log('ZWave: failed to start driver');
+    console.log('failed to start driver');
     this.zwave.disconnect(this.port.comName);
   }
 
   handleDeviceAdded(node) {
     if (this.debugFlow) {
-      console.log('ZWave: handleDeviceAdded:', node.nodeId);
+      console.log('handleDeviceAdded:', node.nodeId);
     }
     delete this.nodesBeingAdded[node.zwInfo.nodeId];
 
@@ -113,7 +113,7 @@ class ZWaveAdapter extends Adapter {
 
   handleDeviceRemoved(node) {
     if (this.debugFlow) {
-      console.log('ZWave: handleDeviceRemoved:', node.nodeId);
+      console.log('handleDeviceRemoved:', node.nodeId);
     }
     delete this.nodes[node.zwInfo.nodeId];
     delete this.nodesBeingAdded[node.zwInfo.nodeId];
@@ -126,7 +126,7 @@ class ZWaveAdapter extends Adapter {
     for (var nodeId in this.nodesBeingAdded) {
       this.handleDeviceAdded(this.nodesBeingAdded[nodeId]);
     }
-    console.log('ZWave: Scan complete');
+    console.log('Scan complete');
     this.ready = true;
     this.zwave.requestAllConfigParams(3);
     this.dump();
@@ -134,7 +134,7 @@ class ZWaveAdapter extends Adapter {
 
   nodeAdded(nodeId) {
     if (DEBUG) {
-      console.log('ZWave: node%d added', nodeId);
+      console.log('node%d added', nodeId);
     }
 
     // Pass in the empty string as a name here. Once the node is initialized
@@ -175,14 +175,14 @@ class ZWaveAdapter extends Adapter {
       }
 
       if (DEBUG || !node.named) {
-        console.log('ZWave: node%d: Named',
+        console.log('node%d: Named',
                     nodeId,
                     zwInfo.manufacturer ? zwInfo.manufacturer :
                                           'id=' + zwInfo.manufacturerId,
                     zwInfo.product ? zwInfo.product :
                                    'product=' + zwInfo.productId +
                                    ', type=' + zwInfo.productType);
-        console.log('ZWave: node%d: name="%s", type="%s", location="%s"',
+        console.log('node%d: name="%s", type="%s", location="%s"',
                     zwInfo.nodeId, node.name, zwInfo.type, zwInfo.location);
       }
       node.named = true;
@@ -190,9 +190,9 @@ class ZWaveAdapter extends Adapter {
       if (DEBUG) {
         for (var comClass in node.zwClasses) {
           var zwClass = node.zwClasses[comClass];
-          console.log('ZWave: node%d: class %d', nodeId, comClass);
+          console.log('node%d: class %d', nodeId, comClass);
           for (var idx in zwClass) {
-            console.log('ZWave: node%d:   %s=%s',
+            console.log('node%d:   %s=%s',
                         nodeId, zwClass[idx].label, zwClass[idx].value);
           }
         }
@@ -202,7 +202,7 @@ class ZWaveAdapter extends Adapter {
 
   nodeRemoved(nodeId) {
     if (DEBUG) {
-      console.log('ZWave: node%d removed', nodeId);
+      console.log('node%d removed', nodeId);
     }
 
     var node = this.nodes[nodeId];
@@ -213,7 +213,7 @@ class ZWaveAdapter extends Adapter {
   }
 
   nodeEvent(nodeId, data) {
-    console.log('ZWave: node%d event: Basic set %d', nodeId, data);
+    console.log('node%d event: Basic set %d', nodeId, data);
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -243,33 +243,33 @@ class ZWaveAdapter extends Adapter {
     var lastStatus;
     switch (notif) {
       case 0:
-        console.log('ZWave: node%d: message complete', nodeId);
+        console.log('node%d: message complete', nodeId);
         lastStatus = 'msgCmplt';
         break;
       case 1:
-        console.log('ZWave: node%d: timeout', nodeId);
+        console.log('node%d: timeout', nodeId);
         lastStatus = 'timeout';
         break;
       case 2:
         if (DEBUG) {
-          console.log('ZWave: node%d: nop', nodeId);
+          console.log('node%d: nop', nodeId);
         }
         lastStatus = 'nop';
         break;
       case 3:
-        console.log('ZWave: node%d: node awake', nodeId);
+        console.log('node%d: node awake', nodeId);
         lastStatus = 'awake';
         break;
       case 4:
-        console.log('ZWave: node%d: node sleep', nodeId);
+        console.log('node%d: node sleep', nodeId);
         lastStatus = 'sleeping';
         break;
       case 5:
-        console.log('ZWave: node%d: node dead', nodeId);
+        console.log('node%d: node dead', nodeId);
         lastStatus = 'dead';
         break;
       case 6:
-        console.log('ZWave: node%d: node alive', nodeId);
+        console.log('node%d: node alive', nodeId);
         lastStatus = 'alive';
         break;
     }
@@ -283,7 +283,7 @@ class ZWaveAdapter extends Adapter {
   }
 
   sceneEvent(nodeId, sceneId) {
-    console.log('ZWave: scene event: nodeId:', nodeId, 'sceneId', sceneId);
+    console.log('scene event: nodeId:', nodeId, 'sceneId', sceneId);
   }
 
   valueAdded(nodeId, comClass, value) {
@@ -309,29 +309,29 @@ class ZWaveAdapter extends Adapter {
 
   // eslint-disable-next-line no-unused-vars
   startPairing(timeoutSeconds) {
-    console.log('ZWave: ===============================================');
-    console.log('ZWave: Press the Inclusion button on the device to add');
-    console.log('ZWave: ===============================================');
+    console.log('===============================================');
+    console.log('Press the Inclusion button on the device to add');
+    console.log('===============================================');
     this.zwave.addNode();
   }
 
   cancelPairing() {
-    console.log('ZWave: Cancelling pairing mode');
+    console.log('Cancelling pairing mode');
     this.zwave.cancelControllerCommand();
   }
 
   // eslint-disable-next-line no-unused-vars
   removeThing(node) {
     // ZWave can't really remove a particular thing.
-    console.log('ZWave: ==================================================');
-    console.log('ZWave: Press the Exclusion button on the device to remove');
-    console.log('ZWave: ==================================================');
+    console.log('==================================================');
+    console.log('Press the Exclusion button on the device to remove');
+    console.log('==================================================');
     this.zwave.removeNode();
   }
 
   // eslint-disable-next-line no-unused-vars
   cancelRemoveThing(node) {
-    console.log('ZWave: Cancelling remove mode');
+    console.log('Cancelling remove mode');
     this.zwave.cancelControllerCommand();
   }
 

--- a/src/addons/zwave-adapter/zwave-classifier.js
+++ b/src/addons/zwave-adapter/zwave-classifier.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-var ZWaveProperty = require('./zwave-property');
+const ZWaveProperty = require('./zwave-property');
 
 // See; http://wiki.micasaverde.com/index.php/ZWave_Command_Classes for a
 // complete list of command classes.
@@ -26,35 +26,49 @@ const THING_TYPE_BINARY_SENSOR = 'binarySensor';
 
 class ZWaveClassifier {
 
-    constructor() {
-    }
+  constructor() {
+  }
 
-    classify(node) {
-        for (var valueId in node.zwValues) {
-            var value = node.zwValues[valueId];
+  classify(node) {
+    for (var valueId in node.zwValues) {
+      var value = node.zwValues[valueId];
 
-            if (value.class_id == COMMAND_CLASS_SWITCH_BINARY) {
-                // This looks like an on/off switch
-                this.initOnOffSwitch(node, valueId);
-                return;
-            } else if (value.class_id == COMMAND_CLASS_SENSOR_BINARY) {
-                this.initBinarySensor(node, valueId);
-                return;
-            }
-        }
+      if (value.class_id == COMMAND_CLASS_SWITCH_BINARY) {
+        // This looks like an on/off switch
+        this.initOnOffSwitch(node, valueId);
+        return;
+      } else if (value.class_id == COMMAND_CLASS_SENSOR_BINARY) {
+        this.initBinarySensor(node, valueId);
+        return;
+      }
     }
+  }
 
-    initOnOffSwitch(node, valueId) {
-        node.type = THING_TYPE_ON_OFF_SWITCH;
-        node.properties.set('on',
-                            new ZWaveProperty(node, 'on', 'boolean', valueId));
-    }
+  initOnOffSwitch(node, valueId) {
+    node.type = THING_TYPE_ON_OFF_SWITCH;
+    node.properties.set('on',
+                        new ZWaveProperty(
+                          node,               // device
+                          'on',               // name
+                          {                   // property decscription
+                            type: 'boolean'
+                          },
+                          valueId             // valueId
+                        ));
+  }
 
-    initBinarySensor(node, valueId) {
-        node.type = THING_TYPE_BINARY_SENSOR;
-        node.properties.set('triggered',
-                            new ZWaveProperty(node, 'on', 'boolean', valueId));
-    }
+  initBinarySensor(node, valueId) {
+    node.type = THING_TYPE_BINARY_SENSOR;
+    node.properties.set('triggered',
+                        new ZWaveProperty(
+                          node,               // device
+                          'on',               // name
+                          {                   // property description
+                            type: 'boolean'
+                          },
+                          valueId             // valueId
+                        ));
+  }
 }
 
 module.exports = new ZWaveClassifier();

--- a/src/addons/zwave-adapter/zwave-node.js
+++ b/src/addons/zwave-adapter/zwave-node.js
@@ -127,11 +127,11 @@ class ZWaveNode extends Device {
     if (zwValue.genre === 'user' || DEBUG) {
       if (property) {
         property.value = zwValue.value;
-        console.log('ZWave: node%d valueAdded: %d:%s -> %s property: %s',
+        console.log('node%d valueAdded: %d:%s -> %s property: %s',
                     this.zwInfo.nodeId, comClass, zwValue.label, zwValue.value,
                     property.name);
       } else {
-        console.log('ZWave: node%d valueAdded: %d:%s -> %s',
+        console.log('node%d valueAdded: %d:%s -> %s',
                     this.zwInfo.nodeId, comClass, zwValue.label, zwValue.value);
       }
     }
@@ -149,12 +149,12 @@ class ZWaveNode extends Device {
     var property = this.findPropertyFromValueId(zwValue.value_id);
     if (property) {
       property.setCachedValue(zwValue.value);
-      console.log('ZWave: node%d valueChanged: %d:%s = %s -> property: %s = %s',
+      console.log('node%d valueChanged: %d:%s = %s -> property: %s = %s',
                   this.zwInfo.nodeId, comClass, zwValue.label, zwValue.value,
                   property.name, property.value);
       this.notifyPropertyChanged(property);
     } else {
-      console.log('ZWave: node%d valueChanged: %d:%s = %s',
+      console.log('node%d valueChanged: %d:%s = %s',
                   this.zwInfo.nodeId, comClass, zwValue.label, zwValue.value);
     }
   }
@@ -170,15 +170,15 @@ class ZWaveNode extends Device {
       if (property) {
         delete property.valueId;
         delete property.value;
-        console.log('ZWave: node%d valueRemoved: %d:%s -> %s property: %s',
+        console.log('node%d valueRemoved: %d:%s -> %s property: %s',
                     this.zwInfo.nodeId, comClass, zwValue.label, zwValue.value,
                     property.name);
       } else {
-        console.log('ZWave: node%d valueRemoved: %d:%s -> %s',
+        console.log('node%d valueRemoved: %d:%s -> %s',
                     this.zwInfo.nodeId, comClass, zwValue.label, zwValue.value);
       }
     } else {
-      console.log('ZWave: zwValueRemoved unknown valueId:', valueId);
+      console.log('zwValueRemoved unknown valueId:', valueId);
     }
   }
 }

--- a/src/addons/zwave-adapter/zwave-property.js
+++ b/src/addons/zwave-adapter/zwave-property.js
@@ -14,8 +14,8 @@ var Deferred = require('../deferred');
 var Property = require('../property');
 
 class ZWaveProperty extends Property {
-  constructor(device, name, type, valueId) {
-    super(device, name, type);
+  constructor(device, name, propertyDescr, valueId) {
+    super(device, name, propertyDescr);
 
     this.valueId = valueId;
     var zwValue = device.zwValues[valueId];
@@ -40,13 +40,13 @@ class ZWaveProperty extends Property {
   setValue(value) {
     var deferredSet = new Deferred();
     if (this.deferredSet) {
-      deferredSet.reject('ZWave: setProperty property ' + this.name +
+      deferredSet.reject('setProperty property ' + this.name +
                          ' already has a set in progress.');
     } else {
       // We don't update the cached value here, but rather
       // wait for the valueChanged notificaton.
 
-      console.log('ZWave: setProperty property:', this.name,
+      console.log('setProperty property:', this.name,
                   'for:', this.device.name,
                   'valueId:', this.valueId,
                   'value:', value);
@@ -57,7 +57,7 @@ class ZWaveProperty extends Property {
                                            value);
         this.deferredSet = deferredSet;
       } else {
-        deferredSet.reject('ZWave: setProperty property ' + this.name +
+        deferredSet.reject('setProperty property ' + this.name +
                           ' for node ' + this.device.id +
                           ' doesn\'t have a valueId');
       }

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,8 @@
 
 const path = require('path');
 
+exports.DONT_RESTART_EXIT_CODE = 100;
+
 exports.USERS_PATH = '/users';
 exports.THINGS_PATH = '/things';
 exports.PROPERTIES_PATH = '/properties';


### PR DESCRIPTION
- added support for dimmable zigbee lights (i.e. ZigBee devices which support the genLevelCtrl cluster)
- modified the adapter loader to not relaunch an addon if it dies due to things like syntax error.
- the plugin class now prefixes any logged lines using the adapter-id (with the string '-adapter' removed).
- added a config parameter to the zigbee adapter which will cause a discover message to be sent to each cluster and the received attributes are then logged. This was used to generate https://github.com/mozilla-iot/wiki/wiki/ZigBee-Attributes
- modified the 3rd argument of the Property class from being just a type to being a property description, so the external adapter repositories will need to be modified and merged around the same time as this change is merged.

- the propertyChanged IPC message was also modified (and the wiki needs to be updated). The original message looks like:
```
{
  messageType: 'propertyChanged',
  data: {
    pluginId: 'pluginId-string',
    adapterId: 'adapterId-string',
    deviceId: 'device-id',
    propertyName: 'name-of-property',
    propertyValue: updated-value,
  },
}
```
The new version looks like:
```
{
  messageType: 'propertyChanged',
  data: {
    pluginId: 'pluginId-string',
    adapterId: 'adapterId-string',
    deviceId: 'device-id',
    property: {
      name: 'property-name',
      value: 'property-value',
      ... remaining fields from property.asDict() ...
    },
  },
}
```
The change to the properyChanged notification allows the property description information to filter up to the PropertyProxy and also allows protocol specific fields to be exposed (this is especially useful when debugging).
This change will affect @hobinjk and his rust implementation of the hue adapter.