### PR TITLE
Report errors during addon installation better

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -695,6 +695,7 @@ class AddonManager extends EventEmitter {
       // Clean up if loading failed
       cleanup();
 
+      console.error(e);
       const err = `Failed to load add-on: ${packageName}\n${e}`;
       console.error(err);
       return Promise.reject(err);


### PR DESCRIPTION
Without this change, you might get an error report like this:
```
Loading add-on: example-adapter
Failed to load add-on: example-adapter
TypeError: Cannot read property 'split' of undefined
```
with this change, the above becomes:
```
Loading add-on: example-adapter
TypeError: Cannot read property 'split' of undefined
    at Plugin.start (/home/dhylands/Dropbox/moziot/gateway/build/webpack:/src/addons/plugin/plugin.js:204:1)
    at PluginServer.loadPlugin (/home/dhylands/Dropbox/moziot/gateway/build/webpack:/src/addons/plugin/plugin-server.js:80:1)
    at AddonManager.loadAddon (/home/dhylands/Dropbox/moziot/gateway/build/webpack:/src/addon-manager.js:448:1)
Failed to load add-on: example-adapter
TypeError: Cannot read property 'split' of undefined
```