### PR TITLE
Verify files list in add-ons, and optional checksums.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -434,20 +434,20 @@ class AddonManager extends EventEmitter {
     //   `rm -f SHA256SUMS && sha256sum file1 file2 ... > SHA256SUMS`
     // To verify, use:
     //   `sha256sum --check SHA256SUMS`
-    const sumsFile = path.join(addonPath, 'SHA256SUMS');
-    if (fs.existsSync(sumsFile)) {
+    if (manifest.files.includes('SHA256SUMS')) {
+      const sumsFile = path.join(addonPath, 'SHA256SUMS');
       try {
-        const data = fs.readFileSync(sumsFile);
-        const lines = data.split(/\r?\n/);
+        const data = fs.readFileSync(sumsFile, 'utf8');
+        const lines = data.trim().split(/\r?\n/);
         for (const line of lines) {
-          const parts = line.split(/\s+/);
+          const parts = line.trim().split(/\s+/);
           if (parts.length !== 2) {
             const err = `Invalid checksum in package ${manifest.name}`;
             console.error(err);
             return Promise.reject(err);
           }
 
-          if (this.hashFile(path.join(addonPath, parts[1]) !== parts[0])) {
+          if (this.hashFile(path.join(addonPath, parts[1])) !== parts[0]) {
             const err =
               `Checksum failed in package ${manifest.name}: ${parts[1]}`;
             console.error(err);

--- a/src/addons-test/mock-adapter/package.json
+++ b/src/addons-test/mock-adapter/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/mozilla-iot/gateway/issues"
   },
+  "files": [
+    "index.js",
+    "mock-adapter.js"
+  ],
   "moziot": {
     "api": {
       "min": 1,

--- a/src/addons-test/settings-adapter/package.json
+++ b/src/addons-test/settings-adapter/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/mozilla-iot/gateway/issues"
   },
+  "files": [
+    "index.js",
+    "settings-adapter.js"
+  ],
   "moziot": {
     "api": {
       "min": 1,

--- a/src/addons/zigbee-adapter/package.json
+++ b/src/addons/zigbee-adapter/package.json
@@ -18,6 +18,15 @@
   "bugs": {
     "url": "https://github.com/mozilla-iot/gateway/issues"
   },
+  "files": [
+    "index.js",
+    "zb-adapter.js",
+    "zb-at.js",
+    "zb-classifier.js",
+    "zb-node.js",
+    "zb-property.js",
+    "zb-zdo.js"
+  ],
   "moziot": {
     "api": {
       "min": 1,

--- a/src/addons/zwave-adapter/package.json
+++ b/src/addons/zwave-adapter/package.json
@@ -18,6 +18,14 @@
   "bugs": {
     "url": "https://github.com/mozilla-iot/gateway/issues"
   },
+  "files": [
+    "index.js",
+    "package.json",
+    "zwave-adapter.js",
+    "zwave-classifier.js",
+    "zwave-node.js",
+    "zwave-property.js"
+  ],
   "moziot": {
     "api": {
       "min": 1,


### PR DESCRIPTION
In case something goes wrong during add-on installation, we can
use the files list and an optional SHA256SUMS file to verify the
add-on's expected contents.