### PR TITLE
Update sqlite3 from 3.1.8 to 3.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rimraf": "^2.6.2",
     "serialport": "^6.0.4",
     "speaktome-api": "^0.1.7",
-    "sqlite3": "^3.1.8",
+    "sqlite3": "^3.1.13",
     "tar": "^4.0.2",
     "uuid": "^3.1.0",
     "winston": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,6 +1484,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
 detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
@@ -2475,7 +2479,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -3820,13 +3824,17 @@ mz@^2.0.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@2.4, nan@~2.4.0:
+nan@2.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
 
 nan@2.6.2, nan@^2.3.0, nan@^2.3.3, nan@^2.6.2, nan@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+nan@~2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
 nanomatch@^1.2.0:
   version "1.2.0"
@@ -3948,7 +3956,7 @@ node-notifier@^5.0.2:
     shellwords "^0.1.0"
     which "^1.2.12"
 
-node-pre-gyp@^0.6.36, node-pre-gyp@~0.6.31:
+node-pre-gyp@^0.6.36:
   version "0.6.36"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
   dependencies:
@@ -3957,6 +3965,22 @@ node-pre-gyp@^0.6.36, node-pre-gyp@~0.6.31:
     npmlog "^4.0.2"
     rc "^1.1.7"
     request "^2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
+node-pre-gyp@~0.6.38:
+  version "0.6.39"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+  dependencies:
+    detect-libc "^1.0.2"
+    hawk "3.1.3"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^2.2.1"
@@ -5115,12 +5139,12 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sqlite3@^3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.8.tgz#4cbcf965d8b901d1b1015cbc7fc415aae157dfaa"
+sqlite3@^3.1.13:
+  version "3.1.13"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
   dependencies:
-    nan "~2.4.0"
-    node-pre-gyp "~0.6.31"
+    nan "~2.7.0"
+    node-pre-gyp "~0.6.38"
 
 sshpk@^1.7.0:
   version "1.13.1"


### PR DESCRIPTION
If you run jest with --runInBand then after running 10 tests, the following
messages show up in the log (after the 10th or 11th test):
```
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGABRT listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGALRM listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGHUP listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGVTALRM listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGXCPU listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGXFSZ listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGUSR2 listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTRAP listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGSYS listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGQUIT listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGIOT listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGIO listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGPOLL listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGPWR listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGSTKFLT listeners added. Use emitter.setMaxListeners() to increase limit
(node:7126) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGUNUSED listeners added. Use emitter.setMaxListeners() to increase limit
```
I was able to narrow this down to the sqlite3 module, and I could demonstrate the problem by running node interactively:
```
510 >node
> process.listenerCount('SIGPWR')
0
> db = require('sqlite3')
{ Database: [Function: Database],
...snip...
  verbose: [Function] }
> process.listenerCount('SIGPWR')
1
>
```
After upgrading to sqlite3 3.1.13, then the listenerCount on 'SIGPWR' stayed at zero.

I didn't investigate if this was caused by sqlite3 or one of its dependecies.

If I logged the listenerCount on SIGPWR then I could see it increment each time a test was run.