### PR TITLE
Run tests sequentially, rather than in parallel

### DIFF
--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -6,4 +6,4 @@ if [ ! -f "certificate.pem" ]; then
   ${SCRIPTDIR}/../../tools/make-self-signed-cert.sh
 fi
 
-jest "$@"
+jest --runInBand "$@"


### PR DESCRIPTION
By default, jest runs the tests in parallel, which causes
us all kinds of grief for things that touch the filesystem.

An example of the kind of problem is described in #460

Currently, the tests take about 8 or 9 seconds to run when run in
parallel, and about 17 seconds to run when run sequentially, so
I'm going to suggest that the extra time isn't really a concern.

This also becomes more of an issue when testing addons, which
requires modifying files on disk.