### PR TITLE
Fix up plugin unloading.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var config = require('config');
+const config = require('config');
 const Constants = require('./constants');
-var EventEmitter = require('events').EventEmitter;
-var Deferred = require('./addons/deferred');
+const EventEmitter = require('events').EventEmitter;
+const Deferred = require('./addons/deferred');
 const PluginClient = require('./addons/plugin/plugin-client');
 const PluginServer = require('./addons/plugin/plugin-server');
 const Settings = require('./models/settings');
@@ -192,6 +192,17 @@ class AddonManager extends EventEmitter {
    */
   getDevices() {
     return this.devices;
+  }
+
+  /**
+   * @method getPlugin
+   *
+   * Returns a previously registered plugin.
+   */
+  getPlugin(pluginId) {
+    if (this.pluginServer) {
+      return this.pluginServer.getPlugin(pluginId);
+    }
   }
 
   /**

--- a/src/addons/deferred.js
+++ b/src/addons/deferred.js
@@ -28,7 +28,7 @@ class Deferred {
       console.log('Deferred: Resolving deferred promise id:', this.id,
                   'arg:', arg);
     }
-    this.resolveFunc(arg);
+    return this.resolveFunc(arg);
   }
 
   reject(arg) {
@@ -36,7 +36,7 @@ class Deferred {
       console.log('Deferred: Rejecting deferred promise id:', this.id,
                   'arg:', arg);
     }
-    this.rejectFunc(arg);
+    return this.rejectFunc(arg);
   }
 }
 

--- a/src/addons/plugin/adapter-proxy.js
+++ b/src/addons/plugin/adapter-proxy.js
@@ -28,7 +28,7 @@ class AdapterProxy extends Adapter {
     super(addonManager, adapterId);
     this.plugin = plugin;
     this.deferredMock = null;
-    this.deferredUnload = null;
+    this.unloadCompletedPromise = null;
   }
 
   startPairing(timeoutSeconds) {
@@ -66,15 +66,15 @@ class AdapterProxy extends Adapter {
    *          finished unloading.
    */
   unload() {
-    if (this.deferredUnload) {
+    if (this.unloadCompletedPromise) {
       console.error('AdapterProxy: unload already in progress');
       return Promise.reject();
     }
-    this.deferredUnload = new Deferred();
+    this.unloadCompletedPromise = new Deferred();
     this.sendMsg(Constants.UNLOAD_ADAPTER, {
       adapterId: this.id,
     });
-    return this.deferredUnload.promise;
+    return this.unloadCompletedPromise.promise;
   }
 
   // The following methods are added to support using the

--- a/src/addons/plugin/addon-manager-proxy.js
+++ b/src/addons/plugin/addon-manager-proxy.js
@@ -116,11 +116,11 @@ class AddonManagerProxy extends EventEmitter {
           //       of the file because at the top of the file, otherwise we
           //       have circular requires and the addonManager object won't
           //       have been created yet.
-          let addonManager = require('../../addon-manager');
+          const addonManager = require('../../addon-manager');
           // NOTE: The call to getPlugin will only succeed when doing
           //       inproc IPC, since getPlugin reaches into server-side
           //       data structures, and we're running on the client.
-          let plugin = addonManager.getPlugin(this.pluginClient.pluginId);
+          const plugin = addonManager.getPlugin(this.pluginClient.pluginId);
           if (plugin && plugin.unloadedRcvdPromise) {
             plugin.unloadedRcvdPromise.promise
               .then((socketsClosedPromise) => {

--- a/src/addons/plugin/addon-manager-proxy.js
+++ b/src/addons/plugin/addon-manager-proxy.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+const config = require('config');
 const Constants = require('../../constants');
 const EventEmitter = require('events').EventEmitter;
 
@@ -98,15 +99,49 @@ class AddonManagerProxy extends EventEmitter {
         return;
 
       case Constants.UNLOAD_ADAPTER:
-        adapter.unload();
-        this.pluginClient.sendNotification(Constants.ADAPTER_UNLOADED, {
-          adapterId: adapter.id,
+        adapter.unload().then(() => {
+          this.pluginClient.sendNotification(Constants.ADAPTER_UNLOADED, {
+            adapterId: adapter.id,
+          });
         });
         return;
 
       case Constants.UNLOAD_PLUGIN:
+        if (config.get('ipc.protocol') === 'inproc') {
+          // When we're testing, we run in the same process and we need
+          // to close the sockets before the adapter.unload promise is
+          // resolved. So we hook into the plugin unloadedRcvdPromise.
+
+          // NOTE: We need to put this require here rather than at the top
+          //       of the file because at the top of the file, otherwise we
+          //       have circular requires and the addonManager object won't
+          //       have been created yet.
+          let addonManager = require('../../addon-manager');
+          // NOTE: The call to getPlugin will only succeed when doing
+          //       inproc IPC, since getPlugin reaches into server-side
+          //       data structures, and we're running on the client.
+          let plugin = addonManager.getPlugin(this.pluginClient.pluginId);
+          if (plugin && plugin.unloadedRcvdPromise) {
+            plugin.unloadedRcvdPromise.promise
+              .then((socketsClosedPromise) => {
+                this.pluginClient.unload();
+                socketsClosedPromise.resolve();
+              });
+          } else {
+            // Wait a small amount of time to allow the pluginUnloaded
+            // message to be processed by the server before closing.
+            setTimeout(() => {
+              this.pluginClient.unload();
+            }, 500);
+          }
+        } else {
+          // Wait a small amount of time to allow the pluginUnloaded
+          // message to be processed by the server before closing.
+          setTimeout(() => {
+            this.pluginClient.unload();
+          }, 500);
+        }
         this.pluginClient.sendNotification(Constants.PLUGIN_UNLOADED, {});
-        this.pluginClient.unload();
         return;
 
       case Constants.CLEAR_MOCK_ADAPTER_STATE:

--- a/src/addons/plugin/plugin-client.js
+++ b/src/addons/plugin/plugin-client.js
@@ -95,13 +95,8 @@ class PluginClient {
   }
 
   unload() {
-    // Wait a small amount of time to allow the pluginUnloaded
-    // message to be processed by the server before closing.
-    setTimeout(() => {
-      this.pluginIpcSocket.close();
-      this.managerIpcSocket.close();
-    }, 500);
-
+    this.pluginIpcSocket.close();
+    this.managerIpcSocket.close();
   }
 }
 

--- a/src/addons/plugin/plugin-server.js
+++ b/src/addons/plugin/plugin-server.js
@@ -70,6 +70,15 @@ class PluginServer {
   }
 
   /**
+   * @method getPlugin
+   *
+   * Returns a previously loaded plugin instance.
+   */
+  getPlugin(pluginId) {
+    return this.plugins.get(pluginId);
+  }
+
+  /**
    * @method loadPlugin
    *
    * Loads a plugin by launching a separate process.

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -77,7 +77,7 @@ class Plugin {
         this.shutdown();
         this.pluginServer.unregisterPlugin(msg.data.pluginId);
         if (this.unloadedRcvdPromise) {
-          let socketsClosedPromise = new Deferred();
+          const socketsClosedPromise = new Deferred();
           if (config.get('ipc.protocol') === 'inproc') {
             // In test mode we want to wait until the sockets are actually
             // closed before we resolve the unloadCompletedPromise.

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -12,7 +12,9 @@
 'use strict';
 
 const AdapterProxy = require('./adapter-proxy');
+const config = require('config');
 const Constants = require('../addon-constants');
+const Deferred = require('../deferred');
 const DeviceProxy = require('./device-proxy');
 const IpcSocket = require('./ipc');
 const readline = require('readline');
@@ -34,10 +36,11 @@ class Plugin {
                                    this.ipcBaseAddr,
                                    this.onMsg.bind(this));
     this.ipcSocket.bind();
-    this.deferredUnload = null;
     this.exec = '';
     this.process = null;
     this.restart = true;
+    this.unloadCompletedPromise = null;
+    this.unloadedRcvdPromise = null;
   }
 
   asDict() {
@@ -60,7 +63,6 @@ class Plugin {
     DEBUG && console.log('Plugin: Rcvd Msg', msg);
     var adapterId = msg.data.adapterId;
     var adapter;
-    var deferredUnload;
 
     // The first switch manages plugin level messages.
     switch (msg.messageType) {
@@ -74,10 +76,26 @@ class Plugin {
       case Constants.PLUGIN_UNLOADED:
         this.shutdown();
         this.pluginServer.unregisterPlugin(msg.data.pluginId);
-        deferredUnload = this.deferredUnload;
-        if (deferredUnload) {
-          this.deferredUnload = null;
-          deferredUnload.resolve();
+        if (this.unloadedRcvdPromise) {
+          let socketsClosedPromise = new Deferred();
+          if (config.get('ipc.protocol') === 'inproc') {
+            // In test mode we want to wait until the sockets are actually
+            // closed before we resolve the unloadCompletedPromise.
+            this.unloadedRcvdPromise.resolve(socketsClosedPromise);
+            this.unloadedRcvdPromise = null;
+          } else {
+            // For non-test mode, the plugin is out-of-process so there is no
+            // way for us to know when then sockets are closed. We won't try
+            // try to restart the plugin until it exits, so there isn't any
+            // problem with resolving the unloadCompletedPromise right away.
+            socketsClosedPromise.resolve();
+          }
+          socketsClosedPromise.promise.then(() => {
+            if (this.unloadCompletedPromise) {
+              this.unloadCompletedPromise.resolve();
+              this.unloadCompletedPromise = null;
+            }
+          });
         }
         return;
     }
@@ -101,18 +119,20 @@ class Plugin {
       case Constants.ADAPTER_UNLOADED:
         this.adapters.delete(adapterId);
         if (this.adapters.size == 0) {
+          // We've unloaded the last adapter for the plugin, now unload
+          // the plugin.
+
           // We may need to reevaluate this, and only auto-unload
           // the plugin for the MockAdapter. For plugins which
           // support hot-swappable dongles (like zwave/zigbee) it makes
           // sense to have a plugin loaded with no adapters present.
           this.unload();
-          this.deferredUnload = adapter.deferredUnload;
-          adapter.deferredUnload = null;
+          this.unloadCompletedPromise = adapter.unloadCompletedPromise;
+          adapter.unloadCompletedPromise = null;
         } else {
-          let deferredUnload = adapter.deferredUnload;
-          if (deferredUnload) {
-            adapter.deferredUnload = null;
-            deferredUnload.resolve();
+          if (adapter.unloadCompletedPromise) {
+            adapter.unloadCompletedPromise.resolve();
+            adapter.unloadCompletedPromise = null;
           }
         }
         break;
@@ -245,6 +265,7 @@ class Plugin {
 
   unload() {
     this.restart = false;
+    this.unloadedRcvdPromise = new Deferred();
     this.sendMsg(Constants.UNLOAD_PLUGIN, {});
   }
 }


### PR DESCRIPTION
These changes allow a plugin to be unloaded and immediately
reloaded as part of a test suite.

Essentially it makes sure that the promise returned by
Adapter.unload doesn't get resolved until the plugin has actually
closed the socket handles in PluginClient.unload(). Without these
changes, trying to reload a plugin during the 1/2 second delay
would cause a conflict. The 1/2 second delay is required during
normal non-test cases to ensure that the gateway has read the
plugin unloaded message before the socket is closed.