### PR TITLE
Make the ZWave adapter be a plugin

### DIFF
--- a/src/addons/zwave-adapter/package.json
+++ b/src/addons/zwave-adapter/package.json
@@ -24,6 +24,7 @@
       "max": 1
     },
     "enabled": true,
-    "plugin": false
+    "plugin": true,
+    "exec": "node ./src/addon-loader.js zwave-adapter"
   }
 }


### PR DESCRIPTION
For some reason, this got overlooked.