### PR TITLE
Fix addon-loader to work properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "serialport": "^6.0.4",
     "speaktome-api": "^0.1.7",
     "sqlite3": "^3.1.13",
+    "string-format": "^0.5.0",
     "string.prototype.padend": "^3.0.0",
     "string.prototype.padstart": "^3.0.0",
     "tar": "^4.0.2",

--- a/src/addon-loader.js
+++ b/src/addon-loader.js
@@ -17,15 +17,12 @@ const PluginClient = require('./addons/plugin/plugin-client');
 const fs = require('fs');
 const path = require('path');
 
-async function loadAddon(packageName, verbose) {
-  const addonPath = path.join(__dirname,
-                              config.get('addonManager.path'),
-                              packageName);
+async function loadAddon(addonPath, verbose) {
 
   // Skip if there's no package.json file.
   const packageJson = path.join(addonPath, 'package.json');
   if (!fs.lstatSync(packageJson).isFile()) {
-    const err = `package.json not found for package: ${packageName}`;
+    const err = `package.json not found: ${packageJson}`;
     return Promise.reject(err);
   }
 
@@ -35,7 +32,7 @@ async function loadAddon(packageName, verbose) {
     data = fs.readFileSync(packageJson);
   } catch (e) {
     const err =
-      `Failed to read package.json for package: ${packageName}\n${e}`;
+      `Failed to read package.json: ${packageJson}\n${e}`;
     return Promise.reject(err);
 }
 
@@ -44,9 +41,10 @@ async function loadAddon(packageName, verbose) {
     manifest = JSON.parse(data);
   } catch (e) {
     const err =
-      `Failed to parse package.json for package: ${packageName}\n${e}`;
+      `Failed to parse package.json: ${packageJson}\n${e}`;
     return Promise.reject(err);
   }
+  let packageName = manifest.name;
 
   // Verify API version.
   const apiVersion = config.get('addonManager.api');
@@ -120,9 +118,9 @@ if (opt.argv.length != 1) {
   console.error('Expecting a single package to load');
   process.exit(Constants.DONT_RESTART_EXIT_CODE);
 }
-var packageName = opt.argv[0];
+var addonPath = opt.argv[0];
 
-loadAddon(packageName, opt.verbose).catch(err => {
+loadAddon(addonPath, opt.verbose).catch(err => {
   console.error(err);
   process.exit(Constants.DONT_RESTART_EXIT_CODE);
 });

--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -362,7 +362,7 @@ class AddonManager extends EventEmitter {
     // Skip if there's no package.json file.
     const packageJson = path.join(addonPath, 'package.json');
     if (!fs.lstatSync(packageJson).isFile()) {
-      const err = `package.json not found for package: ${packageName}`;
+      const err = `package.json not found: ${packageJson}`;
       console.error(err);
       return Promise.reject(err);
     }
@@ -373,7 +373,7 @@ class AddonManager extends EventEmitter {
       data = fs.readFileSync(packageJson);
     } catch (e) {
       const err =
-        `Failed to read package.json for package: ${packageName}\n${e}`;
+        `Failed to read package.json: ${packageJson}\n${e}`;
       console.error(err);
       return Promise.reject(err);
     }
@@ -383,7 +383,7 @@ class AddonManager extends EventEmitter {
       manifest = JSON.parse(data);
     } catch (e) {
       const err =
-        `Failed to parse package.json for package: ${packageName}\n${e}`;
+        `Failed to parse package.json: ${packageJson}\n${e}`;
       console.error(err);
       return Promise.reject(err);
     }
@@ -456,7 +456,7 @@ class AddonManager extends EventEmitter {
       } else {
         // This is the normal plugin adapter case, tell the PluginServer
         // to load the plugin.
-        this.pluginServer.loadPlugin(packageName, manifest);
+        this.pluginServer.loadPlugin(addonPath, manifest);
       }
     } else {
       // Load this add-on directly into the gateway.
@@ -672,6 +672,8 @@ class AddonManager extends EventEmitter {
         });
       }
     };
+
+    console.log(`Expanding add-on ${packagePath} into ${addonPath}`);
 
     try {
       // Try to extract the tarball

--- a/src/addons/plugin/plugin-server.js
+++ b/src/addons/plugin/plugin-server.js
@@ -83,9 +83,10 @@ class PluginServer {
    *
    * Loads a plugin by launching a separate process.
    */
-  loadPlugin(pluginId, manifest) {
-    let plugin = this.registerPlugin(pluginId);
+  loadPlugin(pluginPath, manifest) {
+    let plugin = this.registerPlugin(manifest.name);
     plugin.exec = manifest.moziot.exec;
+    plugin.execPath = pluginPath;
     plugin.start();
   }
 

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -16,7 +16,9 @@ const config = require('config');
 const Constants = require('../addon-constants');
 const Deferred = require('../deferred');
 const DeviceProxy = require('./device-proxy');
+const format = require('string-format');
 const IpcSocket = require('./ipc');
+const path = require('path');
 const readline = require('readline');
 const spawn = require('child_process').spawn;
 
@@ -37,6 +39,7 @@ class Plugin {
                                    this.onMsg.bind(this));
     this.ipcSocket.bind();
     this.exec = '';
+    this.execPath = '.';
     this.process = null;
     this.restart = true;
     this.unloadCompletedPromise = null;
@@ -218,10 +221,19 @@ class Plugin {
   }
 
   start() {
+    const execArgs = {
+      nodeLoader: 'node ./src/addon-loader.js',
+      name: this.pluginId,
+      path: this.execPath,
+    };
+    let execCmd  = format(this.exec, execArgs);
+
+    DEBUG && console.log('  Launching:', execCmd);
+
     // If we need embedded spaces, then consider changing to use the npm
     // module called splitargs
     this.restart = true;
-    let args = this.exec.split(' ');
+    let args = execCmd.split(' ');
     this.process = spawn(args[0], args.slice(1));
 
     this.process.on('error', err => {

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -18,7 +18,6 @@ const Deferred = require('../deferred');
 const DeviceProxy = require('./device-proxy');
 const format = require('string-format');
 const IpcSocket = require('./ipc');
-const path = require('path');
 const readline = require('readline');
 const spawn = require('child_process').spawn;
 

--- a/src/addons/zigbee-adapter/package.json
+++ b/src/addons/zigbee-adapter/package.json
@@ -25,7 +25,7 @@
     },
     "enabled": true,
     "plugin": true,
-    "exec": "node ./src/addon-loader.js zigbee-adapter",
+    "exec": "{nodeLoader} {path}",
     "config": {
       "scanChannels": "0x1ffe",
       "discoverAttributes": false

--- a/src/addons/zwave-adapter/package.json
+++ b/src/addons/zwave-adapter/package.json
@@ -25,6 +25,6 @@
     },
     "enabled": true,
     "plugin": true,
-    "exec": "node ./src/addon-loader.js zwave-adapter"
+    "exec": "{nodeLoader} {path}"
   }
 }

--- a/src/controllers/addons_controller.js
+++ b/src/controllers/addons_controller.js
@@ -102,6 +102,8 @@ AddonsController.post('/', async (request, response) => {
   const tempPath = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
   const destPath = path.join(tempPath, `${name}.tar.gz`);
 
+  console.log(`Fetching add-on ${url} as ${destPath}`);
+
   try {
     const res = await fetch(url);
     const dest = fs.createWriteStream(destPath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5261,6 +5261,10 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
 
+string-format@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/string-format/-/string-format-0.5.0.tgz#bfc4a69a250f17f273d97336797daf5dca6ecf30"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"


### PR DESCRIPTION
Plugins are loaded from the gateway/build tree. Normally __dirname
reflects this, but since the addon-loader is launched separately
from the gateway, it may differ. These changes cause the addon loader
to be told explicitly which directory to load a plugin from.