### PR TITLE
Temporarily disable multilevel switch

### DIFF
--- a/src/addons/zigbee-adapter/zb-classifier.js
+++ b/src/addons/zigbee-adapter/zb-classifier.js
@@ -24,6 +24,8 @@ const CLUSTER_ID_GENLEVELCTRL_HEX = utils.hexStr(CLUSTER_ID_GENLEVELCTRL, 4);
 const THING_TYPE_ON_OFF_SWITCH = 'onOffSwitch';
 const THING_TYPE_MULTI_LEVEL_SWITCH = 'multiLevelSwitch';
 
+const UI_SUPPORTS_MULTILEVEL = false;
+
 class ZigbeeClassifier {
 
   constructor() {
@@ -92,12 +94,14 @@ class ZigbeeClassifier {
   classifyInternal(node) {
     let endpoint;
 
-    endpoint =
-      this.findZhaEndpointWithInputClusterIdHex(node,
-                                                CLUSTER_ID_GENLEVELCTRL_HEX);
-    if (endpoint) {
-      this.initMultiLevelSwitch(node, endpoint);
-      return;
+    if (UI_SUPPORTS_MULTILEVEL) {
+      endpoint =
+        this.findZhaEndpointWithInputClusterIdHex(node,
+                                                  CLUSTER_ID_GENLEVELCTRL_HEX);
+      if (endpoint) {
+        this.initMultiLevelSwitch(node, endpoint);
+        return;
+      }
     }
 
     endpoint =


### PR DESCRIPTION
Without this, a dimmable device shows up in the UI as a ?

Once the UI supports multi-level then changing
the UI_SUPPORTS_MULTILEVEL constant (and if check) can be removed.