### PR TITLE
Kill plugin subprocess on disable/uninstall.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -752,6 +752,7 @@ class AddonManager extends EventEmitter {
       return Promise.resolve();
     }
 
+    const plugin = this.getPlugin(packageName);
     let adapters = this.getAdaptersByPackageName(packageName);
     let unloadPromises = [];
     for (const a of adapters) {
@@ -760,11 +761,13 @@ class AddonManager extends EventEmitter {
       this.adapters.delete(a.id);
     }
 
+    // Give the process 5 seconds to exit before killing it.
     const cleanup = () => {
-      const plugin = this.getPlugin(packageName);
-      if (plugin) {
-        plugin.kill();
-      }
+      setTimeout(() => {
+        if (plugin) {
+          plugin.kill();
+        }
+      }, 5000);
     };
 
     return Promise.all(unloadPromises).then(() => cleanup(), () => cleanup());

--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -760,12 +760,14 @@ class AddonManager extends EventEmitter {
       this.adapters.delete(a.id);
     }
 
-    const plugin = this.getPlugin(packageName);
-    if (plugin) {
-      plugin.kill();
-    }
+    const cleanup = () => {
+      const plugin = this.getPlugin(packageName);
+      if (plugin) {
+        plugin.kill();
+      }
+    };
 
-    return Promise.all(unloadPromises);
+    return Promise.all(unloadPromises).then(() => cleanup(), () => cleanup());
   }
 
   /**

--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -760,6 +760,11 @@ class AddonManager extends EventEmitter {
       this.adapters.delete(a.id);
     }
 
+    const plugin = this.getPlugin(packageName);
+    if (plugin) {
+      plugin.kill();
+    }
+
     return Promise.all(unloadPromises);
   }
 

--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -753,6 +753,11 @@ class AddonManager extends EventEmitter {
     }
 
     const plugin = this.getPlugin(packageName);
+    let pluginProcess = {};
+    if (plugin) {
+      pluginProcess = plugin.process;
+    }
+
     let adapters = this.getAdaptersByPackageName(packageName);
     let unloadPromises = [];
     for (const a of adapters) {
@@ -764,8 +769,9 @@ class AddonManager extends EventEmitter {
     // Give the process 5 seconds to exit before killing it.
     const cleanup = () => {
       setTimeout(() => {
-        if (plugin) {
-          plugin.kill();
+        if (pluginProcess.p) {
+          console.log(`Killing ${packageName} plugin.`);
+          pluginProcess.p.kill();
         }
       }, 5000);
     };

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -282,6 +282,13 @@ class Plugin {
     this.unloadedRcvdPromise = new Deferred();
     this.sendMsg(Constants.UNLOAD_PLUGIN, {});
   }
+
+  kill() {
+    if (this.process) {
+      this.restart = false;
+      this.process.kill();
+    }
+  }
 }
 
 module.exports = Plugin;

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -286,6 +286,8 @@ class Plugin {
   kill() {
     if (this.process) {
       this.restart = false;
+
+      // Kill uses SIGTERM by default
       this.process.kill();
     }
   }

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -39,7 +39,12 @@ class Plugin {
     this.ipcSocket.bind();
     this.exec = '';
     this.execPath = '.';
-    this.process = null;
+
+    // Make this a nested object such that if the Plugin object is reused,
+    // i.e. the plugin is disabled and quickly re-enabled, the gateway process
+    // can maintain a proper reference to the process object.
+    this.process = {p: null};
+
     this.restart = true;
     this.unloadCompletedPromise = null;
     this.unloadedRcvdPromise = null;
@@ -47,8 +52,8 @@ class Plugin {
 
   asDict() {
     let pid = 'not running';
-    if (this.process) {
-      pid = this.process.pid;
+    if (this.process.p) {
+      pid = this.process.p.pid;
     }
     return {
       pluginId: this.pluginId,
@@ -236,9 +241,9 @@ class Plugin {
     // module called splitargs
     this.restart = true;
     let args = execCmd.split(' ');
-    this.process = spawn(args[0], args.slice(1));
+    this.process.p = spawn(args[0], args.slice(1));
 
-    this.process.on('error', err => {
+    this.process.p.on('error', err => {
       // We failed to spawn the process. This most likely means that the
       // exec string is malformed somehow. Report the error but don't try
       // restarting.
@@ -249,33 +254,33 @@ class Plugin {
     });
 
     this.stdoutReadline = readline.createInterface({
-      input: this.process.stdout
+      input: this.process.p.stdout
     });
     this.stdoutReadline.on('line', line => {
       console.log(this.logPrefix + ': ' + line);
     });
 
     this.stderrReadline = readline.createInterface({
-      input: this.process.stderr
+      input: this.process.p.stderr
     });
     this.stderrReadline.on('line', line => {
       console.error(this.logPrefix + ': ' + line);
     });
 
-    this.process.on('exit', code => {
+    this.process.p.on('exit', code => {
       if (this.restart) {
         if (code == Constants.DONT_RESTART_EXIT_CODE) {
           console.log('Plugin:', this.pluginId, 'died, code =', code,
                       'NOT restarting...');
           this.restart = false;
-          this.process = null;
+          this.process.p = null;
         } else {
           console.log('Plugin:', this.pluginId, 'died, code =', code,
                       'restarting...');
           this.start();
         }
       } else {
-        this.process = null;
+        this.process.p = null;
       }
     });
   }
@@ -284,15 +289,6 @@ class Plugin {
     this.restart = false;
     this.unloadedRcvdPromise = new Deferred();
     this.sendMsg(Constants.UNLOAD_PLUGIN, {});
-  }
-
-  kill() {
-    if (this.process) {
-      // Kill uses SIGTERM by default
-      console.log('Plugin: killing', this.pluginId);
-      this.restart = false;
-      this.process.kill();
-    }
   }
 }
 

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -268,11 +268,14 @@ class Plugin {
           console.log('Plugin:', this.pluginId, 'died, code =', code,
                       'NOT restarting...');
           this.restart = false;
+          this.process = null;
         } else {
           console.log('Plugin:', this.pluginId, 'died, code =', code,
                       'restarting...');
           this.start();
         }
+      } else {
+        this.process = null;
       }
     });
   }
@@ -285,9 +288,9 @@ class Plugin {
 
   kill() {
     if (this.process) {
-      this.restart = false;
-
       // Kill uses SIGTERM by default
+      console.log('Plugin: killing', this.pluginId);
+      this.restart = false;
       this.process.kill();
     }
   }

--- a/src/test/integration/plugins-test.js
+++ b/src/test/integration/plugins-test.js
@@ -20,7 +20,7 @@ describe('plugins/', function() {
     // when it exits, so we set restart to false to prevent that.
     plugin.restart = false;
     let promise = new Promise(resolve => {
-      plugin.process.on('exit', code => {
+      plugin.process.p.on('exit', code => {
         console.log('Got exit code', 42);
         resolve(code);
       });
@@ -36,7 +36,7 @@ describe('plugins/', function() {
     plugin.exec = './something-that-doesnt-exist';
     plugin.start();
     let promise = new Promise(resolve => {
-      plugin.process.on('error', err => {
+      plugin.process.p.on('error', err => {
         console.log('Got err.code', err.code);
         resolve(err);
       });
@@ -56,13 +56,13 @@ describe('plugins/', function() {
     plugin.exec = 'node -e process.exit(43);';
 
     let code = await new Promise(resolve => {
-      plugin.process.on('exit', code => {
+      plugin.process.p.on('exit', code => {
         console.log('Got exit code', code);
         if (code == 42) {
           plugin.restart = false;
           // When the process was restarted plugin.process will have
           // been reassigned, so we need to re-register the exit handler.
-          plugin.process.on('exit', code => {
+          plugin.process.p.on('exit', code => {
             console.log('Got exit code', code);
             resolve(code);
           });


### PR DESCRIPTION
Without this, the plugin processes were never being killed off (except when the gateway shut down), so on every disable-enable cycle, or uninstall-install cycle, multiple processes would end up running for the same add-on.