### PR TITLE
Propogate adapter package name to server

### DIFF
--- a/src/addons/plugin/adapter-proxy.js
+++ b/src/addons/plugin/adapter-proxy.js
@@ -24,8 +24,9 @@ const DEBUG = false;
  */
 class AdapterProxy extends Adapter {
 
-  constructor(addonManager, adapterId, plugin) {
-    super(addonManager, adapterId);
+  constructor(addonManager, adapterId, name, packageName, plugin) {
+    super(addonManager, adapterId, packageName);
+    this.name = name;
     this.plugin = plugin;
     this.deferredMock = null;
     this.unloadCompletedPromise = null;

--- a/src/addons/plugin/addon-manager-proxy.js
+++ b/src/addons/plugin/addon-manager-proxy.js
@@ -41,8 +41,9 @@ class AddonManagerProxy extends EventEmitter {
     DEBUG && console.log('AddonManagerProxy: addAdapter:', adapter.id);
     this.adapter = adapter;
     this.pluginClient.sendNotification(Constants.ADD_ADAPTER, {
-      adapterId: adapter.id,
-      name: adapter.name,
+      adapterId: adapter.getId(),
+      name: adapter.getName(),
+      packageName: adapter.getPackageName(),
     });
   }
 

--- a/src/addons/plugin/plugin.js
+++ b/src/addons/plugin/plugin.js
@@ -69,8 +69,11 @@ class Plugin {
     // The first switch manages plugin level messages.
     switch (msg.messageType) {
       case Constants.ADD_ADAPTER:
-        adapter = new AdapterProxy(this.pluginServer.manager, adapterId, this);
-        adapter.name = msg.data.name;
+        adapter = new AdapterProxy(this.pluginServer.manager,
+                                   adapterId,
+                                   msg.data.name,
+                                   msg.data.packageName,
+                                   this);
         this.adapters.set(adapterId, adapter);
         this.pluginServer.addAdapter(adapter);
         return;


### PR DESCRIPTION
Propogate the packageName from the constructed
Adapter class thru to the server side when using a plugin.

Without this change, calls to adapter.getPackageNane on the server side return undefined which means that AddonManager.unloadAddon never calls unloadAdapter

This also fixes the problem where disabling a plugin leaves it running (also see #484)