### PR TITLE
Fix issues with caching static files.

### DIFF
--- a/src/controllers/root_controller.js
+++ b/src/controllers/root_controller.js
@@ -23,7 +23,7 @@ RootController.get('/', TunnelSetup.isTunnelSet,
   function(request, response) {
     response.sendFile('index.html', {
       root: Constants.VIEWS_PATH,
-      maxAge: '14d'
+      maxAge: 0,
     });
   }
 );

--- a/src/router.js
+++ b/src/router.js
@@ -33,8 +33,9 @@ var Router = {
     // Compress all responses larger than 1kb
     app.use(compression());
 
-    // First look for a static file
-    app.use(express.static(Constants.STATIC_PATH, {maxAge: '14d'}));
+    // First look for a static file. Turn off max-age and let the default ETag
+    // handle caching.
+    app.use(express.static(Constants.STATIC_PATH, {maxAge: 0}));
 
     // Content negotiation middleware
     app.use(function(request, response, next) {


### PR DESCRIPTION
The gateway was setting a max age of 14d for static resources.
However, it also sets a weak ETag header by default, which is
better for caching purposes when we're changing files, so we'll
now just rely on the ETag.

I tested this and verified that resources were properly cached
until modified.

Fixes #454