### PR TITLE
Use onPropertyStatus in turnOn and turnOff

### DIFF
--- a/static/js/on-off-switch.js
+++ b/static/js/on-off-switch.js
@@ -137,8 +137,7 @@ OnOffSwitch.prototype.turnOn = function() {
   })
   .then((function(response) {
    if (response.status == 200) {
-     this.showOn();
-     this.properties.on = true;
+     this.onPropertyStatus({on: true});
    } else {
      console.error('Status ' + response.status + ' trying to turn on switch');
    }
@@ -168,8 +167,7 @@ OnOffSwitch.prototype.turnOff = function() {
   })
   .then((function(response) {
     if (response.status == 200) {
-      this.showOff();
-      this.properties.on = false;
+      this.onPropertyStatus({on: false});
     } else {
       console.error('Status ' + response.status + ' trying to turn off switch');
     }


### PR DESCRIPTION
Decrease severity of intermittent issues with onPropertyStatus not being
triggered when websocket is in the process of opening