### PR TITLE
Add support for Hue bulbs using ZHA over Zigbee

### DIFF
--- a/src/addons/plugin/addon-manager-proxy.js
+++ b/src/addons/plugin/addon-manager-proxy.js
@@ -190,9 +190,15 @@ class AddonManagerProxy extends EventEmitter {
         var property = device.findProperty(propertyName);
         if (property) {
           property.setValue(propertyValue).then(_updatedValue => {
-            // We should get a propertyChanged notification thru
-            // the normal channels, so don't sent another one here.
-            // We don't really need to do anything.
+            if (property.fireAndForget) {
+              // This property doesn't send propertyChanged notifications,
+              // so we fake one.
+              this.sendPropertyChangedNotification(property);
+            } else {
+              // We should get a propertyChanged notification thru
+              // the normal channels, so don't sent another one here.
+              // We don't really need to do anything.
+            }
           }).catch(err => {
             // Something bad happened. The gateway is still
             // expecting a reply, so we report the error

--- a/src/addons/property.js
+++ b/src/addons/property.js
@@ -32,6 +32,7 @@ class Property {
     this.device = device;
     this.name = name;
     this.visible = true;
+    this.fireAndForget = false;
     if (propertyDescr.hasOwnProperty('visible')) {
       this.visible = propertyDescr.visible;
     }


### PR DESCRIPTION
This little change will be needed for supporting Hue/Cree bulbs once that code lands in the zigbee adapter. So I thought I'd try and get this into the release.