### PR TITLE
Log to console on failure to parse add-ons list.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -378,7 +378,7 @@ var SettingsScreen = {
           addon.installed = this.installedAddons.has(addon.name);
           new DiscoveredAddon(addon);
         }
-      });
+      }).catch((e) => console.error(`Failed to parse add-ons list: ${e}`));
     });
   },
 


### PR DESCRIPTION
There are no issues with the UI, there's just nothing to display. The back button still works fine.

Fixes #619 