### PR TITLE
Relocate persistent data files into a user profile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@
 .nyc_output/
 /build
 OZW_Log.txt
+config/local.js
 db.sqlite3
 node_modules/
 static/js/lib/stm_web.min.js
-static/uploads/floorplan.svg
+static/uploads
 zwcfg_0x*.xml
 zwscene.xml

--- a/README.md
+++ b/README.md
@@ -118,13 +118,15 @@ $ yarn
 
  Add SSL certificate:
 
- If you don't plan on using Mozilla's provided tunneling service to set up a `*.mozilla-iot.org` domain, you can use your own SSL certificate. The HTTPS server looks for `privatekey.pem` and `certificate.pem`. You can use a real certificate or generate a self-signed one by following the steps below.
+ If you don't plan on using Mozilla's provided tunneling service to set up a `*.mozilla-iot.org` domain, you can use your own SSL certificate. The HTTPS server looks for `privatekey.pem` and `certificate.pem` in the `ssl` sub-directory of the `userProfile` directory specified in your config. You can use a real certificate or generate a self-signed one by following the steps below.
 
  ```
- $ mkdir -p ssl
- $ openssl genrsa -out ssl/privatekey.pem 2048
- $ openssl req -new -sha256 -key ssl/privatekey.pem -out ssl/csr.pem
- $ openssl x509 -req -in ssl/csr.pem -signkey ssl/privatekey.pem -out ssl/certificate.pem
+ $ MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+ $ SSL_DIR="${MOZIOT_HOME}/ssl"
+ $ [ ! -d "${SSL_DIR}" ] && mkdir -p "${SSL_DIR}"
+ $ openssl genrsa -out "${SSL_DIR}/privatekey.pem" 2048
+ $ openssl req -new -sha256 -key "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/csr.pem"
+ $ openssl x509 -req -in "${SSL_DIR}/csr.pem" -signkey "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/certificate.pem"
 ```
 
  Start the web server:
@@ -181,6 +183,7 @@ $ jest src/test/{test-name}.js
   * **`router.js`** - Routes app URLs to controllers
   * **`ssltunnel.js`** - Utilities to determine state of tunnel and manage the PageKite process
   * **`tunnel_setup.js`** - Express middleware to determine if the tunnel is set up
+  * **`user-profile.js`** - Manages persistent user data
 * **`static/`** - Static CSS, JavaScript & image resources for web app front end
 * **`tools/`** - Helpful utilities (not part of the build)
 * **`package.json`** - npm module manifest

--- a/config/default.js
+++ b/config/default.js
@@ -8,13 +8,18 @@
 
 'use strict';
 
+const os = require('os');
+const home = os.homedir();
+
 module.exports = {
   // Expose CLI
   cli: true,
 
+  profileDir: `${home}/.mozilla-iot`,
+
   ports: {
     https: 4443,
-    http: 8080
+    http: 8080,
   },
   // Whether the gateway is behind port forwarding and should use simplified
   // port-free urls
@@ -25,7 +30,6 @@ module.exports = {
     listUrl: 'https://raw.githubusercontent.com/mozilla-iot/addon-list/master/list.json',
   },
   database: {
-    filename: './db.sqlite3',
     removeBeforeOpen: false,
   },
   ipc: {
@@ -43,9 +47,6 @@ module.exports = {
       },
     },
   },
-  uploads: {
-    directory: '../static/uploads/' // Directory to store uploads in
-  },
   authentication: {
     defaultUser: null,
   },
@@ -55,7 +56,7 @@ module.exports = {
     domain: 'mozilla-iot.org',
     pagekite_cmd: './pagekite.py',
     port: 443,
-    certemail: 'certificate@mozilla-iot.org'
+    certemail: 'certificate@mozilla-iot.org',
   },
-  bcryptRounds: 2
+  bcryptRounds: 2,
 };

--- a/config/test.js
+++ b/config/test.js
@@ -26,15 +26,4 @@ module.exports = {
   ipc: {
     protocol: 'inproc',
   },
-  settings: {
-    defaults: {
-    },
-  },
-  uploads: {
-    directory: '../../static/uploads/' // Directory to store uploads in
-  },
-  authentication: {
-    defaultUser: null,
-  },
-  bcryptRounds: 2
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "greenlock": "^2.1.15",
     "jsonwebtoken": "^8.1.0",
     "le-challenge-dns": "https://github.com/mozilla-iot/le-challenge-dns",
+    "mkdirp": "^0.5.1",
     "mustache-express": "^1.2.5",
     "nanomsg": "^3.3.0",
     "nocache": "^2.0.0",

--- a/run-app.sh
+++ b/run-app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+
 run_app() {
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
@@ -16,4 +18,4 @@ run_app() {
   npm start
 }
 
-run_app > ${HOME}/mozilla-iot/gateway/run-app.log 2>&1
+run_app > "${MOZIOT_HOME}/log/run-app.log" 2>&1

--- a/src/controllers/settings_controller.js
+++ b/src/controllers/settings_controller.js
@@ -22,6 +22,7 @@ const path = require('path');
 const TunnelService = require('../ssltunnel');
 const Settings = require('../models/settings');
 const Constants = require('../constants');
+const UserProfile = require('../user-profile');
 
 var SettingsController = PromiseRouter();
 
@@ -106,9 +107,9 @@ SettingsController.post('/subscribe', async (request, response) => {
 
   let leStore = require('le-store-certbot').create({
       webrootPath: Constants.STATIC_PATH,
-      configDir: '~/mozilla-iot/etc',
-      logsDir: '~/mozilla-iot/var/log',
-      workDir: '~/mozilla-iot/var/lib',
+      configDir: path.join(UserProfile.baseDir, 'etc'),
+      logsDir: path.join(UserProfile.baseDir, 'var', 'log'),
+      workDir: path.join(UserProfile.baseDir, 'var', 'lib'),
       debug: true
   });
   let le = greenlock.create({
@@ -180,9 +181,12 @@ SettingsController.post('/subscribe', async (request, response) => {
     console.log('success', results);
 
     // ok. we got the certificates. let's save them
-    fs.writeFileSync(path.join('ssl', 'certificate.pem'), results.cert);
-    fs.writeFileSync(path.join('ssl', 'privatekey.pem'), results.privkey);
-    fs.writeFileSync(path.join('ssl', 'chain.pem'), results.chain);
+    fs.writeFileSync(
+      path.join(UserProfile.sslDir, 'certificate.pem'), results.cert);
+    fs.writeFileSync(
+      path.join(UserProfile.sslDir, 'privatekey.pem'), results.privkey);
+    fs.writeFileSync(
+      path.join(UserProfile.sslDir, 'chain.pem'), results.chain);
 
     // now we associate user's emails with the subdomain, unless it was
     // reclaimed.

--- a/src/controllers/uploads_controller.js
+++ b/src/controllers/uploads_controller.js
@@ -13,10 +13,10 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const config = require('config');
 const Constants = require('../constants');
+const UserProfile = require('../user-profile');
 
-const UPLOADS_PATH = path.join(__dirname, config.get('uploads.directory'));
+const UPLOADS_PATH = UserProfile.uploadDir;
 const FLOORPLAN_PATH = path.join(UPLOADS_PATH, 'floorplan.svg');
 const FALLBACK_FLOORPLAN_PATH = path.join(Constants.STATIC_PATH,
                                           'images',

--- a/src/db.js
+++ b/src/db.js
@@ -13,6 +13,7 @@
 const config = require('config');
 const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
+const path = require('path');
 const Passwords = require('./passwords');
 const assert = require('assert');
 
@@ -38,8 +39,18 @@ var Database = {
    * Open the database.
    */
   open: function() {
-    var filename = config.get('database.filename');
+    // If the database is already open, just return.
+    if (this.db) {
+      return;
+    }
+
+    // Don't pull this from user-profile.js, because that would cause a
+    // circular dependency.
+    const filename =
+      path.join(config.get('profileDir'), 'config', 'db.sqlite3');
+
     var removeBeforeOpen = config.get('database.removeBeforeOpen');
+
     // Check if database already exists
     var exists = fs.existsSync(filename);
     if (exists && removeBeforeOpen) {

--- a/src/ssltunnel.js
+++ b/src/ssltunnel.js
@@ -11,9 +11,10 @@
 const fs = require('fs');
 const config = require('config');
 const path = require('path');
-const Settings = require('./models/settings');
 const fetch = require('node-fetch');
 const spawnSync = require('child_process').spawn;
+const Settings = require('./models/settings');
+const UserProfile = require('./user-profile');
 
 const DEBUG = false || (process.env.NODE_ENV === 'test');
 
@@ -95,8 +96,9 @@ var TunnelService = {
 
     // method to check if the box has certificates
     hasCertificates: function() {
-        return fs.existsSync(path.join('ssl', 'certificate.pem')) &&
-            fs.existsSync(path.join('ssl', 'privatekey.pem'));
+        return fs.existsSync(path.join(UserProfile.sslDir,
+                                       'certificate.pem')) &&
+            fs.existsSync(path.join(UserProfile.sslDir, 'privatekey.pem'));
     },
 
     // method to check if the box has a registered tunnel

--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -2,7 +2,8 @@
 
 SCRIPTDIR="$(dirname ""$0"")"
 
-if [ ! -f "ssl/certificate.pem" ]; then
+MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+if [ ! -f "${MOZIOT_HOME}/ssl/certificate.pem" ]; then
   ${SCRIPTDIR}/../../tools/make-self-signed-cert.sh
 fi
 

--- a/src/tunnel_setup.js
+++ b/src/tunnel_setup.js
@@ -8,10 +8,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var config = require('config');
-var fs = require('fs');
-var path = require('path');
+const config = require('config');
+const fs = require('fs');
+const path = require('path');
 const Settings = require('./models/settings');
+const UserProfile = require('./user-profile');
 
 var TunnelSetup = {
 
@@ -33,8 +34,10 @@ var TunnelSetup = {
             }
 
             // then we check if we have certificates installed
-            if ((fs.existsSync(path.join('ssl', 'certificate.pem'))
-                && fs.existsSync(path.join('ssl', 'privatekey.pem')))
+            if ((fs.existsSync(path.join(UserProfile.sslDir,
+                                         'certificate.pem'))
+                && fs.existsSync(path.join(UserProfile.sslDir,
+                                           'privatekey.pem')))
                 || notunnel) {
                 // if certs are installed,
                 // then we don't need to do anything and return

--- a/src/user-profile.js
+++ b/src/user-profile.js
@@ -1,0 +1,146 @@
+/**
+ * Things Gateway user profile.
+ *
+ * The user profile lives outside of the source tree to allow for things like
+ * data persistence with Docker, as well as the ability to easily switch
+ * profiles, if desired.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const config = require('config');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const mkdirp = require('mkdirp');
+const db = require('./db');
+const Settings = require('./models/settings');
+
+const Profile = {
+  init: function() {
+    this.baseDir = config.get('profileDir');
+    this.configDir = path.join(this.baseDir, 'config');
+    this.sslDir = path.join(this.baseDir, 'ssl');
+    this.uploadDir = path.join(this.baseDir, 'uploads');
+    this.gatewayDir = path.join(__dirname, '..');
+  },
+
+  migrate: function() {
+    // Create all required profile directories.
+    if (!fs.existsSync(this.configDir)) {
+      mkdirp.sync(this.configDir);
+    }
+    if (!fs.existsSync(this.sslDir)) {
+      mkdirp.sync(this.sslDir);
+    }
+    if (!fs.existsSync(this.uploadDir)) {
+      mkdirp.sync(this.uploadDir);
+    }
+
+    // Relocate the database, if necessary, before opening it.
+    const dbPath = path.join(this.configDir, 'db.sqlite3');
+    const oldDbPath = path.join(this.gatewayDir, 'db.sqlite3');
+    if (fs.existsSync(oldDbPath)) {
+      fs.renameSync(oldDbPath, dbPath);
+    }
+
+    // Open the database.
+    db.open();
+
+    // Move the tunneltoken into the database.
+    const ttPath = path.join(this.gatewayDir, 'tunneltoken');
+    if (fs.existsSync(ttPath)) {
+      const token = JSON.parse(fs.readFileSync(ttPath));
+      Settings.set('tunneltoken', token).then(() => {
+        fs.unlinkSync(ttPath);
+      }).catch((e) => {
+        throw e;
+      });
+    }
+
+    // Move the notunnel setting into the database.
+    const ntPath = path.join(this.gatewayDir, 'notunnel');
+    if (fs.existsSync(ntPath)) {
+      Settings.set('notunnel', true).then(() => {
+        fs.unlinkSync(ntPath);
+      }).catch((e) => {
+        throw e;
+      });
+    }
+
+    // Move certificates, if necessary.
+    const pkPath1 = path.join(this.gatewayDir, 'privatekey.pem');
+    const pkPath2 = path.join(this.gatewayDir, 'ssl', 'privatekey.pem');
+    if (fs.existsSync(pkPath1)) {
+      fs.renameSync(pkPath1, path.join(this.sslDir, 'privatekey.pem'));
+    } else if (fs.existsSync(pkPath2)) {
+      fs.renameSync(pkPath2, path.join(this.sslDir, 'privatekey.pem'));
+    }
+
+    const certPath1 = path.join(this.gatewayDir, 'certificate.pem');
+    const certPath2 = path.join(this.gatewayDir, 'ssl', 'certificate.pem');
+    if (fs.existsSync(certPath1)) {
+      fs.renamesync(certPath1, path.join(this.sslDir, 'certificate.pem'));
+    } else if (fs.existsSync(certPath2)) {
+      fs.renameSync(certPath2, path.join(this.sslDir, 'certificate.pem'));
+    }
+
+    const chainPath1 = path.join(this.gatewayDir, 'chain.pem');
+    const chainPath2 = path.join(this.gatewayDir, 'ssl', 'chain.pem');
+    if (fs.existsSync(chainPath1)) {
+      fs.renameSync(chainPath1, path.join(this.sslDir, 'chain.pem'));
+    } else if (fs.existsSync(chainPath2)) {
+      fs.renameSync(chainPath2, path.join(this.sslDir, 'chain.pem'));
+    }
+
+    const oldSslDir = path.join(this.gatewayDir, 'ssl');
+    if (fs.existsSync(oldSslDir)) {
+      fs.rmdirSync(oldSslDir);
+    }
+
+    // Move old uploads, if necessary.
+    const oldUploadDir = path.join(this.gatewayDir, 'static', 'uploads');
+    if (fs.existsSync(oldUploadDir) &&
+        fs.lstatSync(oldUploadDir).isDirectory()) {
+      const fnames = fs.readdirSync(oldUploadDir);
+      for (const fname of fnames) {
+        fs.renameSync(
+          path.join(oldUploadDir, fname), path.join(this.uploadDir, fname));
+      }
+
+      fs.rmdirSync(oldUploadDir);
+      fs.symlinkSync(this.uploadDir, oldUploadDir);
+    }
+
+    // Create a user config if one doesn't exist.
+    const userConfigPath = path.join(this.configDir, 'local.js');
+    if (!fs.existsSync(userConfigPath)) {
+      fs.writeFileSync(
+        userConfigPath, '\'use strict\';\n\nmodule.exports = {\n};');
+    }
+
+    const localConfigPath = path.join(this.gatewayDir, 'config', 'local.js');
+    if (!fs.existsSync(localConfigPath)) {
+      fs.symlinkSync(userConfigPath, localConfigPath);
+    }
+
+    // Move anything that exists in ~/mozilla-iot, such as certbot configs.
+    const oldProfileDir = path.join(os.homedir(), 'mozilla-iot');
+    if (fs.existsSync(oldProfileDir) &&
+        fs.lstatSync(oldProfileDir).isDirectory()) {
+      const fnames = fs.readdirSync(oldProfileDir);
+      for (const fname of fnames) {
+        fs.renameSync(
+          path.join(oldProfileDir, fname), path.join(this.baseDir, fname));
+      }
+
+      fs.rmdirSync(oldProfileDir);
+    }
+  },
+};
+
+module.exports = Profile;

--- a/static/uploads/README.md
+++ b/static/uploads/README.md
@@ -1,1 +1,0 @@
-This folder is used for file uploads.

--- a/tools/config-editor.py
+++ b/tools/config-editor.py
@@ -9,7 +9,11 @@ import sys
 import tempfile
 
 
-_DEFAULT_DATABASE = '/home/pi/mozilla-iot/gateway/db.sqlite3'
+_MOZIOT_HOME = os.getenv('MOZIOT_HOME')
+if not _MOZIOT_HOME:
+    _MOZIOT_HOME = os.path.join(os.path.expanduser('~'), '.mozilla-iot')
+
+_DEFAULT_DATABASE = os.path.join(_MOZIOT_HOME, 'config', 'db.sqlite3')
 _DEFAULT_EDITOR = 'nano'
 
 

--- a/tools/deploy-certificates.sh
+++ b/tools/deploy-certificates.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-gateway_dir="/home/pi/mozilla-iot/gateway"
+MOZIOT_HOME="${MOZIOT_HOME:=/home/pi/.mozilla-iot}"
+SSL_DIR="${MOZIOT_HOME}/ssl"
 
 # Make sure the certificate and private key files are never world readable.
 umask 077
 
 # Copy in the new certs.
-mkdir -p "${gateway_dir}/ssl"
-cp "${RENEWED_LINEAGE}/chain.pem" "${gateway_dir}/ssl/chain.pem"
-cp "${RENEWED_LINEAGE}/cert.pem" "${gateway_dir}/ssl/certificate.pem"
-cp "${RENEWED_LINEAGE}/privkey.pem" "${gateway_dir}/ssl/privatekey.pem"
+[ ! -d "${SSL_DIR}" ] && mkdir -p "${SSL_DIR}"
+cp "${RENEWED_LINEAGE}/chain.pem" "${SSL_DIR}/chain.pem"
+cp "${RENEWED_LINEAGE}/cert.pem" "${SSL_DIR}/certificate.pem"
+cp "${RENEWED_LINEAGE}/privkey.pem" "${SSL_DIR}/privatekey.pem"
 
 # Restart the gateway.
 systemctl restart mozilla-iot-gateway.service

--- a/tools/make-self-signed-cert.sh
+++ b/tools/make-self-signed-cert.sh
@@ -2,7 +2,9 @@
 
 set -x
 
-mkdir -p ssl
-openssl genrsa -out ssl/privatekey.pem 2048
-openssl req -new -sha256 -key ssl/privatekey.pem -out ssl/csr.pem -subj '/CN=www.toizom.com/O=MozillaIoT Gateway/C=US'
-openssl x509 -req -in ssl/csr.pem -signkey ssl/privatekey.pem -out ssl/certificate.pem
+MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+SSL_DIR="${MOZIOT_HOME}/ssl"
+[ ! -d "${SSL_DIR}" ] && mkdir -p "${SSL_DIR}"
+openssl genrsa -out "${SSL_DIR}/privatekey.pem" 2048
+openssl req -new -sha256 -key "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/csr.pem" -subj '/CN=www.toizom.com/O=MozillaIoT Gateway/C=US'
+openssl x509 -req -in "${SSL_DIR}/csr.pem" -signkey "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/certificate.pem"

--- a/tools/manual-renew-certs.sh
+++ b/tools/manual-renew-certs.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This is intended for use with Gateway releases before 0.3.0, as those
+# releases did not have an automatic certificate updater. The certificate
+# paths specified in this script do not match what is currently expected,
+# so DO NOT run this on any releases after 0.3.0. It should be safe on 0.3.0,
+# but should be unnecessary.
+
 script_dir=$(readlink -f $(dirname "$0"))
 moziot_dir="/home/pi/mozilla-iot"
 moziot_email="certificate@mozilla-iot.org"
@@ -120,13 +126,12 @@ kill -15 $(<"${pagekite_pidfile}") >/dev/null 2>&1
 rm -f "${pagekite_pidfile}"
 
 echo "Copying in new certificates."
-mkdir -p "${moziot_dir}/gateway/ssl"
 cp "${moziot_dir}/etc/live/${domain}/cert.pem" \
-    "${moziot_dir}/gateway/ssl/certificate.pem"
+    "${moziot_dir}/gateway/certificate.pem"
 cp "${moziot_dir}/etc/live/${domain}/privkey.pem" \
-    "${moziot_dir}/gateway/ssl/privatekey.pem"
+    "${moziot_dir}/gateway/privatekey.pem"
 cp "${moziot_dir}/etc/live/${domain}/chain.pem" \
-    "${moziot_dir}/gateway/ssl/chain.pem"
+    "${moziot_dir}/gateway/chain.pem"
 
 echo "Registering domain with server."
 curl "http://api.mozilla-iot.org/setemail" \

--- a/tools/renew-certificates.sh
+++ b/tools/renew-certificates.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-moziot_dir="/home/pi/mozilla-iot"
+MOZIOT_HOME="${MOZIOT_HOME:=/home/pi/.mozilla-iot}"
 
 # NOTE: --renew-hook is deprecated and has been replaced by --deploy-hook.
 #       However, the version of certbot in raspbian stretch doesn't have
 #       --deploy-hook support, so we're sticking with the old option for now.
 certbot renew \
-    --config-dir "$moziot_dir/etc" \
-    --logs-dir "$moziot_dir/var/log" \
-    --work-dir "$moziot_dir/var/lib" \
-    --renew-hook "$moziot_dir/gateway/tools/deploy-certificates.sh"
+    --config-dir "${MOZIOT_HOME}/etc" \
+    --logs-dir "${MOZIOT_HOME}/var/log" \
+    --work-dir "${MOZIOT_HOME}/var/lib" \
+    --renew-hook "/home/pi/mozilla-iot/gateway/tools/deploy-certificates.sh"
 
-chown -R pi:pi "$moziot_dir/etc" "$moziot_dir/var"
+chown -R pi:pi "${MOZIOT_HOME}/etc" "${MOZIOT_HOME}/var"


### PR DESCRIPTION
These need to be moved out of the gateway tree for data persistence
when using Docker. This will also allow users to easily switch
profiles, if desired.

Z-Wave logs and such will be handled at the add-on level.