### PR TITLE
Improve SW logic; Remove maxAge cache

### DIFF
--- a/src/controllers/root_controller.js
+++ b/src/controllers/root_controller.js
@@ -22,8 +22,7 @@ const RootController = express.Router();
 RootController.get('/', TunnelSetup.isTunnelSet,
   function(request, response) {
     response.sendFile('index.html', {
-      root: Constants.VIEWS_PATH,
-      maxAge: '14d'
+      root: Constants.VIEWS_PATH
     });
   }
 );

--- a/src/router.js
+++ b/src/router.js
@@ -33,7 +33,7 @@ var Router = {
     app.use(compression());
 
     // First look for a static file
-    app.use(express.static(Constants.STATIC_PATH, {maxAge: '14d'}));
+    app.use(express.static(Constants.STATIC_PATH));
 
     // Content negotiation middleware
     app.use(function(request, response, next) {

--- a/static/js/check-user.js
+++ b/static/js/check-user.js
@@ -12,8 +12,12 @@
     window.API.verifyJWT().then((valid) => {
       if (!valid) {
         redirectUnauthed();
-      } else {
+      } else if (document.body) {
         document.body.classList.remove('hidden');
+      } else {
+        document.addEventListener('DOMContentLoaded', () => {
+          document.body.classList.remove('hidden');
+        });
       }
     });
   } else {


### PR DESCRIPTION
The main effect of this PR is to remove the maxAge cache which disables the low-level caching that would occasionally mess with the SW's higher level fetch-and-update strategy. It also rewrites the SW to use async/await which allowed me to reuse the fetch response without convoluting things too badly. This incorporates #648 