### PR TITLE
execute logic in check-user.js in a domcontentloaded event handler …

### DIFF
--- a/static/js/check-user.js
+++ b/static/js/check-user.js
@@ -37,5 +37,5 @@
     });
   }
 
-  document.addEventListener("DOMContentLoaded", init);
+  document.addEventListener('DOMContentLoaded', init);
 }());

--- a/static/js/check-user.js
+++ b/static/js/check-user.js
@@ -7,17 +7,19 @@
  */
 'use strict';
 
-(function() {
-  if (window.API.isLoggedIn()) {
-    window.API.verifyJWT().then((valid) => {
-      if (!valid) {
-        redirectUnauthed();
-      } else {
-        document.body.classList.remove('hidden');
-      }
-    });
-  } else {
-    redirectUnauthed();
+(function () {
+  function init() {
+    if (window.API.isLoggedIn()) {
+      window.API.verifyJWT().then((valid) => {
+        if (!valid) {
+          redirectUnauthed();
+        } else {
+          document.body.classList.remove('hidden');
+        }
+      });
+    } else {
+      redirectUnauthed();
+    }
   }
 
   function redirectUnauthed() {
@@ -35,4 +37,5 @@
     });
   }
 
+  document.addEventListener("DOMContentLoaded", init);
 }());


### PR DESCRIPTION
I encountered this issue on chrome, where the document.body would be null when the code executed, rendering all the content of the app hidden.
I did not encounter this in firefox.