### PR TITLE
Fix PropertyEffect activation logic

### DIFF
--- a/src/rules-engine/effects/PulseEffect.js
+++ b/src/rules-engine/effects/PulseEffect.js
@@ -38,14 +38,20 @@ class PulseEffect extends Effect {
    * @param {State} state
    */
   setState(state) {
-    if (!this.on && state.on) {
-      this.property.get().then(value => {
+    if (state.on) {
+      // If we're already active, just perform the effect again
+      if (this.on) {
+        return this.property.set(this.value);
+      }
+      // Activate the effect and save our current state to revert to upon
+      // deactivation
+       this.property.get().then(value => {
         this.oldValue = value;
         this.on = true;
         return this.property.set(this.value);
       });
-    }
-    if (this.on && !state.on) {
+    } else if (this.on) {
+      // Revert to our original value
       this.on = false;
       return this.property.set(this.oldValue);
     }


### PR DESCRIPTION
Rules using "Off" as their property trigger fail to reset lights to
their original state. TimeTriggers fail to trigger more than once.

This fixes both behaviors.