### PR TITLE
Remove managed devices when an add-on is disabled.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -756,7 +756,7 @@ class AddonManager extends EventEmitter {
     }
 
     const adapters = this.getAdaptersByPackageName(packageName);
-    const adapterNames = adapters.map((a) => a.id);
+    const adapterIds = adapters.map((a) => a.id);
     const unloadPromises = [];
     for (const a of adapters) {
       console.log('Unloading', a.name);
@@ -774,8 +774,8 @@ class AddonManager extends EventEmitter {
 
         // Remove devices owned by this add-on.
         for (const deviceId of Object.keys(this.devices)) {
-          if (adapterNames.includes(this.devices[deviceId].adapter.id)) {
-            delete this.devices[deviceId];
+          if (adapterIds.includes(this.devices[deviceId].adapter.id)) {
+            this.handleDeviceRemoved(this.devices[deviceId]);
           }
         }
       }, Constants.UNLOAD_PLUGIN_KILL_DELAY);

--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -755,8 +755,9 @@ class AddonManager extends EventEmitter {
       pluginProcess = plugin.process;
     }
 
-    let adapters = this.getAdaptersByPackageName(packageName);
-    let unloadPromises = [];
+    const adapters = this.getAdaptersByPackageName(packageName);
+    const adapterNames = adapters.map((a) => a.id);
+    const unloadPromises = [];
     for (const a of adapters) {
       console.log('Unloading', a.name);
       unloadPromises.push(a.unload());
@@ -769,6 +770,13 @@ class AddonManager extends EventEmitter {
         if (pluginProcess.p) {
           console.log(`Killing ${packageName} plugin.`);
           pluginProcess.p.kill();
+        }
+
+        // Remove devices owned by this add-on.
+        for (const deviceId of Object.keys(this.devices)) {
+          if (adapterNames.includes(this.devices[deviceId].adapter.id)) {
+            delete this.devices[deviceId];
+          }
         }
       }, Constants.UNLOAD_PLUGIN_KILL_DELAY);
     };


### PR DESCRIPTION
This prevents unowned devices from showing up in the "Add Things"
screen.