### PR TITLE
Update README on setting up a *.mozilla-iot.org domains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,25 @@ run `npm install --global yarn` or for a more secure installation follow the
 $ yarn
 ```
 
- Add SSL certificate:
+Set up domain:
 
- If you don't plan on using Mozilla's provided tunneling service to set up a `*.mozilla-iot.org` domain, you can use your own SSL certificate. The HTTPS server looks for `privatekey.pem` and `certificate.pem` in the `ssl` sub-directory of the `userProfile` directory specified in your config. You can use a real certificate or generate a self-signed one by following the steps below.
+You can use  Mozilla's provided tunneling service to set up a `*.mozilla-iot.org` domain.
+If you plan to use your own SSL certificate, please jump to next section on "Add own SSL certificate".
+
+Start the web server:
+
+```
+$ npm start
+```
+
+Load ```https://localhost:8080``` in your web browser (or use the server's IP address if loading remotely).
+Then follow the instructions on the webpage to set up domain and register. Once this is done you can Load
+```https://localhost:4443``` in your web browser (or use the server's IP address if loading remotely).
+
+
+ Add own SSL certificate:
+
+ The HTTPS server looks for `privatekey.pem` and `certificate.pem` in the `ssl` sub-directory of the `userProfile` directory specified in your config. You can use a real certificate or generate a self-signed one by following the steps below.
 
  ```
  $ MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Start the web server:
 $ npm start
 ```
 
-Load ```https://localhost:8080``` in your web browser (or use the server's IP address if loading remotely).
+Load ```http://localhost:8080``` in your web browser (or use the server's IP address if loading remotely).
 Then follow the instructions on the webpage to set up domain and register. Once this is done you can Load
 ```https://localhost:4443``` in your web browser (or use the server's IP address if loading remotely).
 

--- a/README.md
+++ b/README.md
@@ -94,65 +94,57 @@ change goes through.
 
 ## Download and Build Gateway
 
-Clone the GitHub repository (or fork it first):
-```
-$ cd
-$ git clone https://github.com/mozilla-iot/gateway.git
-```
+* Clone the GitHub repository (or fork it first):
 
-Change into the gateway directory:
+    ```
+    $ cd
+    $ git clone https://github.com/mozilla-iot/gateway.git
+    ```
 
-```
-$ cd gateway
-```
+* Change into the gateway directory:
 
-Install dependencies:
+    ```
+    $ cd gateway
+    ```
 
-NOTE: `yarn` is preferred but `npm install` will also work. To install `yarn`
-run `npm install --global yarn` or for a more secure installation follow the
-[directions for your OS](https://yarnpkg.com/en/docs/install).
+* Install dependencies:
+    * **NOTE**: `yarn` is preferred but `npm install` will also work. To install `yarn`
+    run `npm install --global yarn` or for a more secure installation follow the
+    [directions for your OS](https://yarnpkg.com/en/docs/install).
 
-```
-$ yarn
-```
+    ```
+    $ yarn
+    ```
 
-Set up domain:
+* Set up domain:
+    * If you plan to use Mozilla's provided tunneling service to set up a `*.mozilla-iot.org` domain:
+        * Start the web server:
 
-You can use  Mozilla's provided tunneling service to set up a `*.mozilla-iot.org` domain.
-If you plan to use your own SSL certificate, please jump to next section on "Add own SSL certificate".
+            ```
+            $ npm start
+            ```
+            
+        * Load `http://localhost:8080` in your web browser (or use the server's IP address if loading remotely). Then follow the instructions on the web page to set up domain and register. Once this is done you can load
+`https://localhost:4443` in your web browser (or use the server's IP address if loading remotely).
+    * If you plan to use your own SSL certificate:
+        * The HTTPS server looks for `privatekey.pem` and `certificate.pem` in the `ssl` sub-directory of the `userProfile` directory specified in your config. You can use a real certificate or generate a self-signed one by following the steps below.
 
-Start the web server:
+            ```
+            $ MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+            $ SSL_DIR="${MOZIOT_HOME}/ssl"
+            $ [ ! -d "${SSL_DIR}" ] && mkdir -p "${SSL_DIR}"
+            $ openssl genrsa -out "${SSL_DIR}/privatekey.pem" 2048
+            $ openssl req -new -sha256 -key "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/csr.pem"
+            $ openssl x509 -req -in "${SSL_DIR}/csr.pem" -signkey "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/certificate.pem"
+            ```
 
-```
-$ npm start
-```
+        * Start the web server:
 
-Load ```http://localhost:8080``` in your web browser (or use the server's IP address if loading remotely).
-Then follow the instructions on the webpage to set up domain and register. Once this is done you can Load
-```https://localhost:4443``` in your web browser (or use the server's IP address if loading remotely).
+            ```
+            $ npm start
+            ```
 
-
- Add own SSL certificate:
-
- The HTTPS server looks for `privatekey.pem` and `certificate.pem` in the `ssl` sub-directory of the `userProfile` directory specified in your config. You can use a real certificate or generate a self-signed one by following the steps below.
-
- ```
- $ MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
- $ SSL_DIR="${MOZIOT_HOME}/ssl"
- $ [ ! -d "${SSL_DIR}" ] && mkdir -p "${SSL_DIR}"
- $ openssl genrsa -out "${SSL_DIR}/privatekey.pem" 2048
- $ openssl req -new -sha256 -key "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/csr.pem"
- $ openssl x509 -req -in "${SSL_DIR}/csr.pem" -signkey "${SSL_DIR}/privatekey.pem" -out "${SSL_DIR}/certificate.pem"
-```
-
- Start the web server:
-
-```
-$ npm start
-```
-
-Load ```https://localhost:4443``` in your web browser (or use the server's IP address if loading remotely).
-Since you're using a self-signed certificate, you'll need to add a security exception in the browser.
+        * Load `https://localhost:4443` in your web browser (or use the server's IP address if loading remotely). Since you're using a self-signed certificate, you'll need to add a security exception in the browser.
 
 ## Debugging
 


### PR DESCRIPTION
This is to make it clear for first time user on different
steps between using Mozilla's provided tunnel service and
using self-signed certificate.

Signed-off-by: Ziran Sun <ziran.sun@samsung.com>