### PR TITLE
Enable CORS

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -49,6 +49,7 @@ var Router = {
     app.use(function(request, response, next) {
       // Inform the browser that content negotiation is taking place
       response.setHeader('Vary', 'Accept');
+
       // If request won't accept HTML but will accept JSON,
       // or is a WebSocket request, or is multipart/form-data
       // treat it as an API request
@@ -56,6 +57,11 @@ var Router = {
           request.get('Upgrade') === 'websocket' ||
           request.is('multipart/form-data') ||
           request.path.startsWith(Constants.LOGS_PATH)) {
+        // Enable CORS for API requests
+        response.setHeader('Access-Control-Allow-Origin', '*');
+        response.setHeader('Access-Control-Allow-Headers',
+          'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+
         request.url = API_PREFIX + request.url;
         next();
       // Otherwise treat it as an app request


### PR DESCRIPTION
Based on @sogaani's comment in #767, should make things a bit happier for Angular and other uses of xhr instead of fetch/ws.