### PR TITLE
UI Fix: Hide authorization screen before login. (#757)

### DIFF
--- a/src/views/authorize.mustache
+++ b/src/views/authorize.mustache
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="/js/api.js"></script>
     <script type="text/javascript" src="/js/check-user.js"></script>
   </head>
-  <body>
+  <body class="hidden">
     <img id="wordmark" src="../images/moziot-wordmark.png" alt="Mozilla IoT"/>
 
     <!-- OAuth Authorization -->

--- a/static/css/authorize.css
+++ b/static/css/authorize.css
@@ -59,3 +59,7 @@ body {
 #authorize-button {
   background-image: url(/images/check-16.svg);
 }
+
+body.hidden {
+  visibility: hidden;
+}


### PR DESCRIPTION
Authorization screen is temporarily shown when using oauth
with not logined client. The fix is to put class='hidden'
on body for /oauth/authorize page.

Fixes #757

Signed-off-by: Ziran Sun <ziran.sun@samsung.com>