### PR TITLE
Only install Python 3 version of adapt parser.

### DIFF
--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -58,7 +58,6 @@ sudo pip2 install "$_url"
 sudo pip3 install "$_url"
 
 _url="git+https://github.com/mycroftai/adapt#egg=adapt-parser"
-sudo pip2 install "$_url"
 sudo pip3 install "$_url"
 
 git clone https://github.com/mozilla-iot/intent-parser "$HOME/mozilla-iot/intent-parser"


### PR DESCRIPTION
The intent parser runs with Python 3, so there's no reason to have
a Python2 version of adapt parser.