### PR TITLE
Implement and expose scope/readwrite restriction

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -80,3 +80,9 @@ exports.THING_TYPE_DIMMABLE_COLOR_LIGHT = 'dimmableColorLight';
 exports.UNLOAD_ADAPTER = 'unloadAdapter';
 exports.UNLOAD_PLUGIN = 'unloadPlugin';
 exports.UNPAIR_MOCK_DEVICE = 'unpairMockDevice';
+
+exports.ACCESS_TOKEN = 'access_token';
+exports.AUTHORIZATION_CODE = 'authorization_code';
+exports.USER_TOKEN = 'user_token';
+exports.READWRITE = 'readwrite';
+exports.READ = 'read';

--- a/src/models/jsonwebtoken.js
+++ b/src/models/jsonwebtoken.js
@@ -69,14 +69,13 @@ class JSONWebToken {
    *
    * @param {ClientRegistry} client to issue token for.
    * @param {number} user user id associated with token
-   * @param {string} role for token to fulfill
+   * @param {{role: String, scope: String}} payload of token
    * @return {string} the JWT token signature.
    */
-  static async issueOAuthToken(client, user, role) {
-    const {sig, token} = this.create(user, {
-      role,
+  static async issueOAuthToken(client, user, payload) {
+    const {sig, token} = this.create(user, Object.assign({
       client_id: client.id
-    });
+    }, payload));
     await Database.createJSONWebToken(token);
     return sig;
   }

--- a/src/models/oauthclients.ts
+++ b/src/models/oauthclients.ts
@@ -50,8 +50,8 @@ class OAuthClients {
 
 let oauthClients = new OAuthClients();
 oauthClients.register(
-  new ClientRegistry(new URL('http://127.0.0.1:31338/callback'), 'hello',
-                     'Hello', 'super secret', 'readwrite')
+  new ClientRegistry(new URL('http://127.0.0.1:31338/callback'), 'test',
+                     'Test OAuth Client', 'super secret', '/things:readwrite')
 );
 
 export default oauthClients;

--- a/src/oauth-types.ts
+++ b/src/oauth-types.ts
@@ -1,11 +1,17 @@
 import { URL } from 'url';
+import * as Constants from './constants';
 
-export type Scope = 'readwrite';
+type Read = 'read';
+type ReadWrite = 'readwrite';
+export type ScopeAccess = Read|ReadWrite;
+export type Scope = {[path: string]: ScopeAccess};
+
+export type ScopeRaw = string;
 export type ClientId = string;
 
 export class ClientRegistry {
   constructor(public redirect_uri: URL, public id: ClientId, public name: string,
-              public secret: string, public scope: Scope) {
+              public secret: string, public scope: ScopeRaw) {
   }
 
   getDescription() {
@@ -16,4 +22,57 @@ export class ClientRegistry {
       scope: this.scope
     };
   }
+}
+
+function stringToScope(scopeRaw: ScopeRaw): Scope {
+  let scope: Scope = {};
+  let scopeParts = scopeRaw.split(' ');
+  for (let scopePart of scopeParts) {
+    let parts = scopePart.split(':');
+    let path = parts[0];
+    let readwrite = parts[1];
+    if (readwrite !== 'read' && readwrite !== 'readwrite') {
+      readwrite = 'read';
+    }
+    scope[path] = readwrite as 'read'|'readwrite';
+  }
+
+  return scope;
+}
+
+export function scopeValidSubset(clientScopeRaw: ScopeRaw, requestScopeRaw: ScopeRaw): boolean {
+  if (clientScopeRaw === requestScopeRaw) {
+    return true;
+  }
+  let clientScope = stringToScope(clientScopeRaw);
+  let requestScope = stringToScope(requestScopeRaw);
+
+  if (!clientScope || !requestScope) {
+    return false;
+  }
+
+  for (let requestPath in requestScope) {
+    if (!requestPath.startsWith(Constants.THINGS_PATH)) {
+      console.warn('Invalid request for out-of-bounds scope', requestScopeRaw);
+      return false;
+    }
+    let requestAccess = requestScope[requestPath];
+    let access: ScopeAccess|undefined;
+    if (clientScope[requestPath]) {
+      access = clientScope[requestPath];
+    } else {
+      access = clientScope[Constants.THINGS_PATH];
+    }
+
+    if (!access) {
+      return false;
+    }
+
+    if (requestAccess === 'readwrite') {
+      if (access !== 'readwrite') {
+        return false;
+      }
+    }
+  }
+  return true;
 }

--- a/src/test/models/oauth-test.js
+++ b/src/test/models/oauth-test.js
@@ -1,0 +1,24 @@
+const {scopeValidSubset} = require('../../oauth-types');
+
+describe('OAuth types', function() {
+  it('should verify scopes', () => {
+    expect(
+      scopeValidSubset('/things:read', '/things/potato:readwrite')).toBeFalsy();
+
+    expect(
+      scopeValidSubset('/things:readwrite',
+                       '/things/potato:readwrite')).toBeTruthy();
+
+    expect(
+      scopeValidSubset('/things/potato:readwrite /things/tomato:read',
+                       '/things/potato:readwrite')).toBeTruthy();
+
+    expect(
+      scopeValidSubset('/things/potato:read /things/tomato:readwrite',
+                       '/things/potato:readwrite')).toBeFalsy();
+
+    expect(
+      scopeValidSubset('/things/potato:read /things/tomato:readwrite',
+                       '/things:readwrite')).toBeFalsy();
+  });
+});

--- a/src/views/authorize.mustache
+++ b/src/views/authorize.mustache
@@ -11,10 +11,13 @@
     <link rel="manifest" href="/app.webmanifest">
     <link rel="icon" href="/images/icon.png" type="image/png" />
     <link rel="stylesheet" type="text/css" href="/css/app.css" />
+    <link rel="stylesheet" type="text/css" href="/css/thing.css" />
     <link rel="stylesheet" type="text/css" href="/css/authorize.css" />
 
+    <script type="text/javascript" src="/js/utils.js"></script>
     <script type="text/javascript" src="/js/api.js"></script>
     <script type="text/javascript" src="/js/check-user.js"></script>
+    <script type="text/javascript" src="/js/authorize.js"></script>
   </head>
   <body class="hidden">
     <img id="wordmark" src="../images/moziot-wordmark.png" alt="Mozilla IoT"/>
@@ -27,23 +30,34 @@
       </div>
 
       <form id="authorize-form" method="get" action="allow">
-        <p><b>{{name}}</b> would like to access your gateway to monitor and control devices.</p>
+        <p><b>{{name}}</b> would like to access your gateway to
+          <span class="authorize-select-container">
+            <select class="authorize-select">
+              <option id="authorize-readwrite">monitor and control</option>
+              <option id="authorize-read">monitor</option>
+            </select>
+          </span>
+        devices.</p>
         <p><small>from {{domain}}</small></p>
+        <ul id="authorize-things">
+          <li class="authorize-all-things">
+            <input id="authorize-all-things" type="checkbox" class="generic-checkbox">
+            <label for="authorize-all-things">
+              Allow for all Things
+            </label>
+          </li>
+        </ul>
+
         <input name="response_type" value="{{request.response_type}}" type="hidden">
         <input name="client_id" value="{{request.client_id}}" type="hidden">
-        <input name="scope" value="{{request.scope}}" type="hidden">
+        <input id="authorize-scope" name="scope" value="{{request.scope}}" type="hidden">
         <input name="state" value="{{request.state}}" type="hidden">
         <input id="jwt" name="jwt" value="" type="hidden">
+
         <input id="authorize-button" type="submit" value="Allow" class="text-button" disabled>
         <a id="cancel-button" href="/" class="text-button">Deny</a>
       </form>
     </section>
-
-    <script type="text/javascript">
-      let jwt = document.getElementById('jwt');
-      jwt.value = window.API.jwt;
-      document.getElementById('authorize-button').removeAttribute('disabled');
-    </script>
   </body>
 </html>
 

--- a/static/css/authorize.css
+++ b/static/css/authorize.css
@@ -2,6 +2,10 @@ body {
   background: #305067;
 }
 
+body.hidden {
+  visibility: hidden;
+}
+
 .title-bar {
   text-align: center;
   width: 100%;
@@ -27,14 +31,11 @@ body {
 }
 
 #authorize-form {
-  position: absolute;
-
-  top: 50%;
-  width: 100%;
-  transform: translateY(-50%);
   text-align: center;
   color: white;
   font-size: 1.8rem;
+  max-width: 60rem;
+  margin: 0 auto;
 }
 
 .text-button {
@@ -60,6 +61,52 @@ body {
   background-image: url(/images/check-16.svg);
 }
 
-body.hidden {
-  visibility: hidden;
+.generic-checkbox + label::before {
+  float: none;
+  position: relative;
+  top: 0.8rem;
+  left: -0.1rem;
+}
+
+#authorize-things {
+  text-align: left;
+  list-style: none;
+  display: block;
+}
+
+.authorize-all-things {
+  padding-bottom: 1.6rem;
+  margin-bottom: 0.8rem;
+  border-bottom: 1px solid #d9dee3;
+}
+
+.authorize-select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+
+  background: none;
+  color: white;
+  border: 0;
+  font-size: 1.8rem;
+}
+
+.authorize-select-container {
+  position: relative;
+  display: inline-block;
+  border-bottom: 2px solid white;
+}
+
+.authorize-select-container:after {
+  border-top: 0.6rem solid white;
+  border-left: 0.6rem solid transparent;
+  border-right: 0.6rem solid transparent;
+  content: '';
+  position: absolute;
+  transform: translate(-50%, 0.2rem);
+  top: 100%;
+  left: 50%;
+  height: 0;
+  width: 0;
 }

--- a/static/js/authorize.js
+++ b/static/js/authorize.js
@@ -1,0 +1,96 @@
+/* global API, Utils */
+
+document.addEventListener('DOMContentLoaded', () => {
+  let jwt = document.getElementById('jwt');
+  jwt.value = API.jwt;
+
+  let scope = document.getElementById('authorize-scope');
+  init(scope.value);
+});
+
+function init(scope) {
+  let readWrite = scope.indexOf(':readwrite') >= 0;
+  let authorizeReadWrite = document.getElementById('authorize-readwrite');
+  let authorizeRead = document.getElementById('authorize-read');
+  let authorizeThings = document.getElementById('authorize-things');
+  let authorizeButton = document.getElementById('authorize-button');
+  let authorizeScope = document.getElementById('authorize-scope');
+  let authorizeAllThings = document.getElementById('authorize-all-things');
+
+  if (readWrite) {
+    authorizeReadWrite.setAttribute('selected', '');
+  } else {
+    authorizeRead.setAttribute('selected', '');
+  }
+
+  let global = scope.split(':')[0] === '/things';
+
+  if (global) {
+    authorizeAllThings.setAttribute('checked', '');
+  }
+
+  fetch('/things', {
+    headers: API.headers()
+  }).then(res => {
+    return res.json();
+  }).then(things => {
+    let checkboxIndex = 0;
+    for (let thing of things) {
+      let included = global || (scope.indexOf(thing.href) >= 0);
+      let elt = document.createElement('li');
+      elt.classList.add('authorize-thing');
+      elt.dataset.href = Utils.escapeHtml(thing.href);
+      elt.innerHTML = `
+        <input id="authorize-thing-included-${checkboxIndex}"
+          class="authorize-thing-included generic-checkbox"
+          type="checkbox" ${included ? 'checked' : ''}
+          ${global ? 'disabled' : ''}/>
+        <label for="authorize-thing-included-${checkboxIndex}">
+          ${Utils.escapeHtml(thing.name)}
+        </label>`;
+      checkboxIndex += 1;
+
+      authorizeThings.appendChild(elt);
+    }
+  });
+
+
+  authorizeAllThings.addEventListener('change', function() {
+    let authorizeThings = document.querySelectorAll('.authorize-thing');
+    for (let thingElt of authorizeThings) {
+      let checkbox = thingElt.querySelector('.authorize-thing-included');
+      if (authorizeAllThings.checked) {
+        checkbox.checked = authorizeAllThings.checked;
+        checkbox.disabled = true;
+      } else {
+        checkbox.disabled = false;
+      }
+    }
+  });
+
+  authorizeButton.addEventListener('click', function() {
+    let readWrite = 'read';
+    if (authorizeReadWrite.selected) {
+      readWrite = 'readwrite';
+    }
+
+    let urls = [];
+    // read scope from .authorize-thing
+    if (authorizeAllThings.checked) {
+      urls.push('/things');
+    } else {
+      let authorizeThings = document.querySelectorAll('.authorize-thing');
+      for (let thingElt of authorizeThings) {
+        if (thingElt.querySelector('.authorize-thing-included').checked) {
+          urls.push(thingElt.dataset.href);
+        }
+      }
+    }
+
+    authorizeScope.value = urls.map(url => {
+      return url + ':' + readWrite;
+    }).join(' ');
+  });
+
+  authorizeButton.removeAttribute('disabled');
+}


### PR DESCRIPTION
Adds a `scope` value to access token's payloads, restricting their use to a subset of paths on the gateway.

For example, '/things:readwrite' allows all access to all things. '/things/light1:read' allows only the GET and OPTIONS methods on '/things/light1'.

<img width="645" alt="auth-request" src="https://user-images.githubusercontent.com/2776089/37921949-382e824e-30f9-11e8-91c8-79823a702b4c.png">
