### PR TITLE
Have run-tests start the intent-parser

### DIFF
--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -3,10 +3,41 @@
 SCRIPTDIR="$(dirname ""$0"")"
 
 MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
-MOZIOT_HOME="${MOZIOT_HOME}/test"
-if [ ! -f "${MOZIOT_HOME}/ssl/certificate.pem" ]; then
-  export MOZIOT_HOME
-  ${SCRIPTDIR}/../../tools/make-self-signed-cert.sh
+MOZIOT_TEST_HOME="${MOZIOT_HOME}/test"
+if [ ! -f "${MOZIOT_TEST_HOME}/ssl/certificate.pem" ]; then
+  MOZIOT_HOME="${MOZIOT_TEST_HOME}" ${SCRIPTDIR}/../../tools/make-self-signed-cert.sh
 fi
 
+# Check to see if the adapt module is installed
+if ! python -c 'import adapt'; then
+  sudo pip install git+https://github.com/mycroftai/adapt#egg=adapt-parser
+fi
+
+# install or update the intent parser
+(
+  cd ${MOZIOT_TEST_HOME};
+  if [ -d intent-parser ]; then
+    echo "Skipping git pull"
+    #cd intent-parser
+    #git pull
+  else
+    git clone https://github.com/mozilla-iot/intent-parser
+  fi
+)
+
+# cleanup code to kill the intent parser when this script exits
+function cleanup() {
+  if [ ! -z "${INTENT_SERVER_PID}" ]; then
+    sleep 1
+    echo "Killing intent parser pid ${INTENT_SERVER_PID}"
+    kill ${INTENT_SERVER_PID}
+  fi
+}
+trap cleanup EXIT
+
+# Fire up the intent parser
+python "${MOZIOT_TEST_HOME}/intent-parser/intent-parser-server.py" &
+INTENT_SERVER_PID=$!
+
+# Run the tests
 jest --runInBand "$@"

--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -17,9 +17,8 @@ fi
 (
   cd ${MOZIOT_TEST_HOME};
   if [ -d intent-parser ]; then
-    echo "Skipping git pull"
-    #cd intent-parser
-    #git pull
+    cd intent-parser
+    git pull
   else
     git clone https://github.com/mozilla-iot/intent-parser
   fi

--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -10,7 +10,7 @@ fi
 
 # Check to see if the adapt module is installed
 if ! python -c 'import adapt'; then
-  sudo pip install git+https://github.com/mycroftai/adapt#egg=adapt-parser
+  pip install --user git+https://github.com/mycroftai/adapt#egg=adapt-parser
 fi
 
 # install or update the intent parser


### PR DESCRIPTION
This combined with https://github.com/mozilla-iot/intent-parser/pull/4 allows `npm test` to work locally.