### PR TITLE
Disable Travis's IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,3 @@ after_script:
 node_js:
   - 8
   - 9
-notifications:
-  irc: "irc.mozilla.org#iot"


### PR DESCRIPTION
They can get pretty spammy, especially since all forks also send their travis information to the same channel. The main positive effect of the integration is that I notice when the build is broken, but of the times that I have investigated it has always been an issue with Travis's infrastructure and not with our code.