### PR TITLE
install: Update repo before installing packages

### DIFF
--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -25,8 +25,9 @@
 NVM_VERSION="v0.33.8"
 NODE_VERSION="--lts"
 
-sudo apt update
+sudo apt update -y
 sudo apt upgrade -y
+sudo apt update -y
 
 # Install and configure nvm
 curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash


### PR DESCRIPTION
Sources are refreshed again to prevent a failure
in looking up packages in manifest files,

I suppose it's because of timestamp changes after upgrade.

Also make update non interactive.

Observed issue:

    cd ~/mozilla-iot/gateway && bash -x -e ./install.sh
    (...)
    + sudo apt install -y certbot dnsmasq git hostapd libffi-dev libnanomsg-dev libnanomsg4 libudev-dev libusb-1.0-0-dev python-pip python3-pip sqlite3
    (...)
    Package libusb-1.0-0-dev is not available, but is referred to by another package.
    (...)
    E: Unable to locate package certbot

Change-Id: Ic1afddcbe51908c5f999ccf45bad20edcc2386d6
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>