### PR TITLE
Fix a crash when Applying config to a disabled addon

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -791,9 +791,10 @@ class AddonManager extends EventEmitter {
         unloadPromises.push(a.unload());
         this.adapters.delete(a.id);
       }
-    } else {
+    } else if (plugin) {
       // If there are no adapters, manually unload the plugin, otherwise it
-      // will just restart.
+      // will just restart. Note that if the addon is disabled, then
+      // there might not be a plugin either.
       plugin.unload();
     }
 


### PR DESCRIPTION
Steps to reproduce:
1 - Setup the GPIO adapter with no configured pins
2 - Disable the GPIO adapter
3 - Configure the GPIO adapter to add a pin
4 - Press Apply

I then saw:
```
2018-04-19 17:37:32.241 TypeError: Cannot read property 'unload' of undefined
    at AddonManager.unloadAddon (/home/pi/mozilla-iot/gateway/build/webpack:/src/addon-manager.js:799:1)
    at ./src/controllers/addons_controller.js.AddonsController.put (/home/pi/mozilla-iot/gateway/build/webpack:/src/controllers/addons_controller.js:121:1)
    at <anonymous>
```
This happens because clicking apply does an unload/reload of the addon, but
since the gpio adapter was previously disabled, there is no plugin.