### PR TITLE
Fix: fail loading js files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,6 +87,7 @@ const webpackJs = {
   output: {
     path: path.join(__dirname, 'build/static'),
     filename: 'js/[name].js',
+    publicPath: '/',
   },
   module: {
     rules: [


### PR DESCRIPTION
When refresh page on '/settings/user', browser try to load '/settings/js/0.js' which is loading dynamically and it is not exists path.
This patch force to load '/js/0.js' on loading any pages.