### PR TITLE
Fix array schema

### DIFF
--- a/src/test/schema-form/array-field-test.js
+++ b/src/test/schema-form/array-field-test.js
@@ -99,6 +99,20 @@ describe('ArrayField', () => {
         .toEqual(true);
     });
 
+    it('should convert non-array data to array', () => {
+      const {schemaForm, node} = createSchemaForm({
+        schema,
+        formData: {},
+      });
+
+      node.querySelector('.btn-add').click();
+
+      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      expect(inputs).toHaveLength(1);
+      // eslint-disable-next-line no-undefined
+      expect(schemaForm.formData).toEqual([undefined]);
+    });
+
     it('should fill an array field with data', () => {
       const {node} = createSchemaForm({
         schema,

--- a/static/js/addons-config/array-field.js
+++ b/static/js/addons-config/array-field.js
@@ -29,7 +29,7 @@ function ArrayField(
   disabled = false,
   readonly = false) {
   this.schema = SchemaUtils.retrieveSchema(schema, definitions, formData);
-  this.formData = formData || [];
+  this.formData = Array.isArray(formData) ? formData : [];
   this.idSchema = idSchema;
   this.name = name;
   this.definitions = definitions;


### PR DESCRIPTION
When the add-on have JSON-schema which have array field on root and have no config, an error occur.
```
    "schema": {
      "type": "array",
      "title": "addable field",
      "items": {
        "type": "string"
      }
    },
``` 