### PR TITLE
Add ChoiceDetail type

### DIFF
--- a/static/css/thing.css
+++ b/static/css/thing.css
@@ -141,6 +141,30 @@
   background-image: url('../images/bulb-off.png');
 }
 
+
+/* Choice Detail */
+
+.choice-detail {
+
+}
+
+.choice-detail .choice-input {
+    max-width: 95%;
+    background-color: rgba(0,0,0,0);
+    color: white;
+    border: none;
+    font-size: 0.9em;
+    overflow: hidden;
+    max-width: 95%;
+    outline: none;
+    text-align: center;
+    text-align-last: center;
+}
+
+.choice-detail .choice-input option {
+    color: black; /* Needed to fix dropdown text color on Windows */
+}
+
 /* Color Light */
 
 .on-off-label, .color-light-label {

--- a/static/js/choice-detail.js
+++ b/static/js/choice-detail.js
@@ -1,0 +1,72 @@
+/**
+ * ChoiceDetail
+ *
+ * A bubble showing property choices that can be set on a thing
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const Utils = require('./utils');
+
+function ChoiceDetail(thing, name, friendlyName, unit, choices) {
+  this.thing = thing;
+  this.name = name;
+  this.friendlyName = friendlyName;
+  this.unit = unit;
+  this.choices = choices;
+  this.select_css_id = `choice-${this.name}`;
+
+}
+
+ChoiceDetail.prototype.attach = function() {
+  this.select = this.thing.element.querySelector(`#${this.select_css_id}`);
+  this.select.addEventListener('change', this.set.bind(this));
+};
+
+ChoiceDetail.prototype.view = function() {
+  const currentChoice = this.thing.properties[this.name];
+
+  let choicesHTML = '';
+  for (const choiceName of this.choices) {
+      choicesHTML += `<option value="${choiceName}">${choiceName} ${this.unit}</option>`;
+  }
+  return `<div class="thing-detail-container choice-detail-container">` +
+         `  <div class="thing-detail choice-detail">` +
+         `    <div class="thing-detail-contents">` +
+         `      <select id="${this.select_css_id}"` +
+         `              class="choice-input"` +
+         `              value="${Utils.escapeHtml(currentChoice)}">` +
+         `        ${choicesHTML}` +
+         `      </select>` +
+         `    </div>` +
+         `  </div>` +
+         `  <div class="thing-detail-label">${Utils.escapeHtml(this.friendlyName)}</div>` +
+         `</div>`;
+};
+
+ChoiceDetail.prototype.update = function() {
+  if (!this.select) {
+    return;
+  }
+
+  const newValue = this.thing.properties[this.name];
+
+  const currentValue = this.select.value;
+
+  if (newValue == currentValue) {
+    return;
+  }
+
+  this.select.value = newValue;
+};
+
+ChoiceDetail.prototype.set = function() {
+  const selectedChoice = this.select.value;
+  this.thing.setProperty(this.name, selectedChoice);
+};
+
+module.exports = ChoiceDetail;

--- a/static/js/things.js
+++ b/static/js/things.js
@@ -15,6 +15,7 @@ const AddThingScreen = require('./add-thing');
 const UnknownThing = require('./unknown-thing');
 const OnOffSwitch = require('./on-off-switch');
 const BinarySensor = require('./binary-sensor');
+const ChoiceDetail = require('./choice-detail');
 const ColorLight = require('./color-light');
 const DimmableLight = require('./dimmable-light');
 const DimmableColorLight = require('./dimmable-color-light');


### PR DESCRIPTION
Greetings :)

As part of my work on [picamera-webthing](https://github.com/infincia/picamera-webthing) I've added several types to the Gateway.

This one, `ChoiceDetail`, is essentially a lightly styled HTML `select` element that allows the parent `Thing` to supply a list of options for it via the `choices` argument in the `ChoiceDetail` constructor.

It passes the selected choice to the `Thing` via the `Thing.setProperty(name, value)` call. This follows the example of the generic Detail types used by `UnknownThing`, allowing an arbitrary number of `ChoiceDetail` to be used by a `Thing` and preventing them from being closely coupled together.

The CSS here is just enough to avoid making the `select` element look out of place in a Detail bubble and may need some further thought on the best look & feel. You can see what it looks like in the `picamera-webthing` repo, which uses `ChoiceDetail` for the 'Resolution', 'Framerate', and 'Exposure'  properties.

## Other Gateway Changes

The choices should really be provided by the property description of the Web Thing itself, rather than hardcoded in the `Thing` in the Gateway, however that appears to require some changes in other parts of the Gateway to whitelist a new `choices` key, as it doesn't currently show up in the browser when adding a new Thing.

You can see an example of how this might work on the Web Thing side [here](https://github.com/infincia/picamera-webthing/blob/374eae1/picamera-webthing.py#L274), and an example of the Gateway side [here](https://github.com/infincia/gateway/blob/550a168/static/js/camera.js#L102).

The Web Thing declares a property of type `choice`, and provides a list of choices in the `choices` key. The Gateway side reacts to the presence of one or more `choice` properties, rather than expecting one to exist with a specific name, and then uses the provided `choices` list, if available.

Thanks :)