### PR TITLE
Remove css-loader option which minimize css

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,7 +153,6 @@ const webpackCssHtml = {
           use: {
             loader: 'css-loader',
             options: {
-              minimize: true,
               sourceMap: true,
             },
           },


### PR DESCRIPTION
Minimize option can make incorrect CSS.
https://github.com/webpack-contrib/css-loader/issues/688