### PR TITLE
Sort discovered add-ons by display name.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -483,9 +483,9 @@ const SettingsScreen = {
       const addonList = document.getElementById('discovered-addons-list');
       addonList.innerHTML = '';
 
-      for (const name of Array.from(this.availableAddons.keys()).sort()) {
-        new DiscoveredAddon(this.availableAddons.get(name));
-      }
+      Array.from(this.availableAddons.entries())
+        .sort((a, b) => a[1].displayName.localeCompare(b[1].displayName))
+        .forEach((x) => new DiscoveredAddon(x[1]));
     });
   },
 


### PR DESCRIPTION
When sorted by package name, things can get out of order, i.e.
thing-url-adapter has a different sort position than "Web Thing".