### PR TITLE
Fix issue with hiding menu.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -55,6 +55,7 @@ const SettingsScreen = {
     this.backButton.href = '/settings';
 
     if (section) {
+      Menu.hide();
       this.showSection(section, subsection, id);
     } else {
       this.showMenu();


### PR DESCRIPTION
STR:
1. Open menu
2. Click Settings (menu closes)
3. Open menu
4. Click Add-ons (menu stays open, cannot be closed)

This would also be fixed by #846, if that is preferred.