### PR TITLE
install: Fix typo in I2C enabler scriptlet

### DIFF
--- a/image/make-prep.sh
+++ b/image/make-prep.sh
@@ -102,7 +102,7 @@ END
   fi
 
   CONF="${ROOT_MOUNTPOINT}/etc/modules"
-  if sudo grep -q "i2c-dev" "${CONF}:"; then
+  if sudo grep -q "i2c-dev" "${CONF}"; then
     sudo sed -i "s/.*i2c-dev/i2c-dev/g" "${CONF}"
   else
     sudo sh -c "cat >> '${CONF}'" <<END


### PR DESCRIPTION
Not critical but will prevent a log error

Change-Id: Ide393597b7885cb247677872fd37ee5d3e0cf31a
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>