### PR TITLE
install: Download autotools for gifsicle

### DIFF
--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -44,6 +44,7 @@ sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
 
 # Install prequisite packages
 sudo apt install -y \
+  autoconf \
   certbot \
   dnsmasq \
   git \
@@ -51,6 +52,7 @@ sudo apt install -y \
   libffi-dev \
   libnanomsg-dev \
   libnanomsg4 \
+  libtool \
   libudev-dev \
   libusb-1.0-0-dev \
   python-pip \


### PR DESCRIPTION
Observed issue was:

  > gifsicle@3.0.4 postinstall (...)
  > node lib/install.js
  (...)
  ℹ compiling from source
  ✖ Error: autoreconf -ivf (...)
  Command failed: autoreconf -ivf
  /bin/sh: 1: autoreconf: not found

Note, this should have break the prepare script,
I am investigating why It was ignored,

Anyway problem is not specific to gateway,
it can be reproduced on other modules too:

  cd ~/mozilla-iot/gateway $ npm install mozjpeg

Change-Id: I13491a57241721283ef9f8c6d86d1b92bb3d9e56
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>