### PR TITLE
Fix issue where registration page was never displayed.

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -43,8 +43,16 @@ const Router = {
     });
 
     // First look for a static file
+    const staticHandler = express.static(Constants.BUILD_STATIC_PATH);
     app.use('/uploads', express.static(UserProfile.uploadsDir));
-    app.use(express.static(Constants.BUILD_STATIC_PATH));
+    app.use((request, response, next) => {
+      if (request.path === '/' && request.accepts('html')) {
+        // We need this to hit RootController.
+        next();
+      } else {
+        staticHandler(request, response, next);
+      }
+    });
 
     // Content negotiation middleware
     app.use(function(request, response, next) {


### PR DESCRIPTION
Since index.html was moved into static/ for webpack purposes,
RootController was never being hit, as index.html was being served
by the static file handler. Since RootController was never used,
the user was never being redirected to the domain registration
page.