### PR TITLE
Update cross compile scripts

### DIFF
--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -18,6 +18,9 @@
 #   - /build/Open-ZWave/open-zwave  - git repository containing the desired version of OpenZWave
 #   - /build/gateway                - git repository containing the gateway software
 
+NVM_VERSION="v0.33.8"
+NODE_VERSION="--lts"
+
 GATEWAY=gateway
 OPEN_ZWAVE=OpenZWave/open-zwave
 
@@ -61,9 +64,36 @@ INSTALL_OPENZWAVE="PREFIX=/usr make  -C ${OPEN_ZWAVE} CROSS_COMPILE=arm-linux-gn
 sudo ${INSTALL_OPENZWAVE}
 sudo DESTDIR=${SYSROOT} ${INSTALL_OPENZWAVE}
 
+# Setup Cross compiler vars which are used by node-gyp when building native node modules.
+OPTS="--sysroot=${SYSROOT}"
+export CC="arm-linux-gnueabihf-gcc ${OPTS}"
+export CXX="arm-linux-gnueabihf-g++ ${OPTS}"
+
+# Install and configure nvm
+curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+# The following 2 lines are installed into ~/.bashrc by the above,
+# but on the RPi, sourcing ~/.bashrc winds up being a no-op (when sourced
+# from a script), so we just run it here.
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"  # This loads nvm
+nvm install ${NODE_VERSION}
+nvm use ${NODE_VERSION}
+
+# Allow node to use the Bluetooth adapter
+sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
+
+npm install -g yarn
+
+# Build the node modules, compiling any native code with cross compiler.
+(cd ${GATEWAY}; yarn --ignore-scripts; ./image/rebuild-node-modules.sh cross --arch=${ARCH} --target_arch=arm; chmod -R +r node_modules)
+nvm unload
+
 # Build the node modules, compiling any native code with arm emulator.
+unset CC
+unset CXX
 export RPXC_UID=builder
-rpdo "cd ${GATEWAY} && source /home/builder/.nvm/nvm.sh && yarn"
+sudo chown -R 1000.1000 ${GATEWAY}/node_modules
+rpdo "cd ${GATEWAY} && source /home/builder/.nvm/nvm.sh && ./image/rebuild-node-modules.sh native"
 
 set -x
 

--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -2,18 +2,21 @@
 #
 # This script is expected to run inside a docker container which has the Raspberry Pi toolchain
 # and required prerequisites:
-#   - pkg-config
-#   - libusb-1.0-0-dev
 #   - libudev-dev
+#   - libpng-dev
+#   - autoconf
+#   - curl
+#   - pkg-config
+#   - python
+#   - python2.7
+#   - git
+#   - build-essential
 #
 # /build corresponds to the current directory when the docker container is run and it is expected
 # that the following directory structure has been setup:
 #
 #   - /build/Open-ZWave/open-zwave  - git repository containing the desired version of OpenZWave
 #   - /build/gateway                - git repository containing the gateway software
-
-NVM_VERSION="v0.33.8"
-NODE_VERSION="--lts"
 
 GATEWAY=gateway
 OPEN_ZWAVE=OpenZWave/open-zwave
@@ -58,28 +61,9 @@ INSTALL_OPENZWAVE="PREFIX=/usr make  -C ${OPEN_ZWAVE} CROSS_COMPILE=arm-linux-gn
 sudo ${INSTALL_OPENZWAVE}
 sudo DESTDIR=${SYSROOT} ${INSTALL_OPENZWAVE}
 
-# Setup Cross compiler vars which are used by node-gyp when building native node modules.
-OPTS="--sysroot=${SYSROOT}"
-export CC="arm-linux-gnueabihf-gcc ${OPTS}"
-export CXX="arm-linux-gnueabihf-g++ ${OPTS}"
-
-# Install and configure nvm
-curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
-# The following 2 lines are installed into ~/.bashrc by the above,
-# but on the RPi, sourcing ~/.bashrc winds up being a no-op (when sourced
-# from a script), so we just run it here.
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"  # This loads nvm
-nvm install ${NODE_VERSION}
-nvm use ${NODE_VERSION}
-
-# Allow node to use the Bluetooth adapter
-sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
-
-npm install -g yarn
-
-# Build the node modules, cross compiling any native code.
-(cd ${GATEWAY}; yarn --ignore-scripts; npm rebuild --arch=${ARCH} --target_arch=arm)
+# Build the node modules, compiling any native code with arm emulator.
+export RPXC_UID=builder
+rpdo "cd ${GATEWAY} && source /home/builder/.nvm/nvm.sh && yarn"
 
 set -x
 

--- a/image/builder/Dockerfile
+++ b/image/builder/Dockerfile
@@ -1,0 +1,46 @@
+FROM sdthirlwall/raspberry-pi-cross-compiler
+
+ARG NVM_VERSION="v0.33.8"
+ARG NODE_VERSION="--lts"
+
+# Install binary packages
+RUN set -x &&\
+        apt-get update &&\
+        apt-get -y upgrade &&\
+        rpdo apt-get update &&\
+        rpdo apt-get -y upgrade &&\
+        install-raspbian -y libudev-dev &&\
+        install-raspbian -y libpng-dev &&\
+        install-raspbian -y autoconf &&\
+        install-raspbian -y curl &&\
+        install-raspbian -y pkg-config &&\
+        install-raspbian -y python &&\
+        install-raspbian -y python2.7 &&\
+        install-raspbian -y git &&\
+        install-raspbian -y build-essential
+
+# Make device files on sysroot.
+ADD makeproc.sh /usr/bin/makeproc.sh
+RUN set -x &&\
+        makeproc.sh &&\
+        chmod 666 /rpxc/sysroot/dev/null &&\
+        mknod -m 644 /rpxc/sysroot/dev/random c 1 8 &&\
+        mknod -m 644 /rpxc/sysroot/dev/urandom c 1 9 &&\
+        chown root:root /rpxc/sysroot/dev/random /rpxc/sysroot/dev/urandom
+
+RUN set -x &&\
+        rpdo ln -f -s /bin/bash /bin/sh
+
+# Add user for build
+ADD rpdo /usr/bin/rpdo
+RUN set -x &&\
+        rpdo useradd -m builder
+
+ENV RPXC_UID builder
+ENV HOME /home/builder
+RUN set -x &&\
+        rpdo curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | rpdo bash &&\
+        rpdo "source $HOME/.nvm/nvm.sh && nvm install ${NODE_VERSION}" &&\
+        rpdo "source $HOME/.nvm/nvm.sh && nvm use ${NODE_VERSION}" &&\
+        rpdo "source $HOME/.nvm/nvm.sh && npm config set unsafe-perm true" &&\
+        rpdo "source $HOME/.nvm/nvm.sh && npm install -g yarn"

--- a/image/builder/Dockerfile
+++ b/image/builder/Dockerfile
@@ -2,45 +2,46 @@ FROM sdthirlwall/raspberry-pi-cross-compiler
 
 ARG NVM_VERSION="v0.33.8"
 ARG NODE_VERSION="--lts"
+ADD makeproc.sh /usr/bin/makeproc.sh
+ADD rpdo /usr/bin/rpdo
 
 # Install binary packages
 RUN set -x &&\
-        apt-get update &&\
-        apt-get -y upgrade &&\
-        rpdo apt-get update &&\
-        rpdo apt-get -y upgrade &&\
-        install-raspbian -y libudev-dev &&\
-        install-raspbian -y libpng-dev &&\
-        install-raspbian -y autoconf &&\
-        install-raspbian -y curl &&\
-        install-raspbian -y pkg-config &&\
-        install-raspbian -y python &&\
-        install-raspbian -y python2.7 &&\
-        install-raspbian -y git &&\
-        install-raspbian -y build-essential
-
+        apt-get -y update &&\
+        rpdo apt-get -y update &&\
+        install-raspbian -y \
+                libudev-dev \
+                libpng-dev \
+                autoconf \
+                libtool \
+                curl \
+                pkg-config \
+                python \
+                python2.7 \
+                git \
+                build-essential &&\
+        install-debian -y \
+                pkg-config \
+                python \
+                python2.7 &&\
+# cleanup
+        rpdo "apt-get clean" &&\
+        rpdo "rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*" &&\
 # Make device files on sysroot.
-ADD makeproc.sh /usr/bin/makeproc.sh
-RUN set -x &&\
         makeproc.sh &&\
         chmod 666 /rpxc/sysroot/dev/null &&\
         mknod -m 644 /rpxc/sysroot/dev/random c 1 8 &&\
         mknod -m 644 /rpxc/sysroot/dev/urandom c 1 9 &&\
-        chown root:root /rpxc/sysroot/dev/random /rpxc/sysroot/dev/urandom
-
-RUN set -x &&\
-        rpdo ln -f -s /bin/bash /bin/sh
-
+        chown root:root /rpxc/sysroot/dev/random /rpxc/sysroot/dev/urandom &&\
+        rpdo "ln -f -s /bin/bash /bin/sh" &&\
 # Add user for build
-ADD rpdo /usr/bin/rpdo
-RUN set -x &&\
         rpdo useradd -m builder
 
+# Install nvm for native compile
 ENV RPXC_UID builder
 ENV HOME /home/builder
 RUN set -x &&\
         rpdo curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | rpdo bash &&\
         rpdo "source $HOME/.nvm/nvm.sh && nvm install ${NODE_VERSION}" &&\
         rpdo "source $HOME/.nvm/nvm.sh && nvm use ${NODE_VERSION}" &&\
-        rpdo "source $HOME/.nvm/nvm.sh && npm config set unsafe-perm true" &&\
-        rpdo "source $HOME/.nvm/nvm.sh && npm install -g yarn"
+        rpdo "source $HOME/.nvm/nvm.sh && npm config set unsafe-perm true"

--- a/image/builder/makeproc.sh
+++ b/image/builder/makeproc.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# make /proc/cpuinfo
+echo > /rpxc/sysroot/proc/cpuinfo
+IFS=$'\n';
+count=0
+for LINE in `cat /proc/cpuinfo | grep processor`; do
+  sh -c 'cat >> /rpxc/sysroot/proc/cpuinfo' <<END
+processor       : $count
+model name      : ARMv7 Processor rev 4 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xd03
+CPU revision    : 4
+
+END
+  let ++count
+done
+
+sh -c 'cat >> /rpxc/sysroot/proc/cpuinfo' <<END
+Hardware        : BCM2709
+Revision        : a02082
+Serial          : 00000000354915813
+END
+
+# make /proc/stat
+sh -c 'cat > /rpxc/sysroot/proc/stat' <<END
+cpu  0 0 0 0 0 0 0 0 0 0
+END
+
+count=0
+for LINE in `cat /proc/cpuinfo | grep processor`; do
+  sh -c 'cat >> /rpxc/sysroot/proc/stat' <<END
+cpu$count  0 0 0 0 0 0 0 0 0 0
+END
+  let ++count
+done

--- a/image/builder/rpdo
+++ b/image/builder/rpdo
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# cd into $SYSROOT so that $PWD is inside the chroot
+cd $SYSROOT
+
+# Execute raspbian binaries using the qemu-arm-static emulator, while chrooted
+# to the sysroot.
+# If we're running as the $RPXC_USER we need to sudo to root to perform the
+# chroot, and then drop back down to the user afterwards.
+if [ -z "$RPXC_UID" ]; then
+    chroot $SYSROOT \
+        $QEMU_PATH /bin/sh -c "cd /build && $*"
+else
+    export HOME=/home/$RPXC_UID
+    sudo -E chroot --userspec $RPXC_UID:$RPXC_GID $SYSROOT \
+        $QEMU_PATH /bin/sh -c "cd /build && $*"
+fi

--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -52,6 +52,7 @@ sudo apt install -y \
   libffi-dev \
   libnanomsg-dev \
   libnanomsg4 \
+  libpng12-0 \
   libtool \
   libudev-dev \
   libusb-1.0-0-dev \

--- a/image/rebuild-node-modules.sh
+++ b/image/rebuild-node-modules.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+SCRIPT_NAME=$(basename $0)
+NUM_PROCESS=2
+
+###########################################################################
+#
+# Prints the program usage
+#
+usage() {
+  cat <<END
+./image/${SCRIPT_NAME} <cmd>
+
+where cmd can be one of:
+  cross             build node_modules which can be cross builded.
+  native            Build node_modules which need to be native builded.
+END
+}
+
+
+###########################################################################
+#
+# Mark node_module to need native build.
+#
+markNativeBuild() {
+  local name=$1
+  NativeModules+=(${name})
+}
+
+###########################################################################
+#
+# Correct node_modules installed.
+#
+readInstalled() {
+  InstalledModules=(`find node_modules/ -name package.json | sed 's/.*\/\([^\/]*\)\/package\.json/\1/g' | awk '!colname[$1]++{print $1}'`)
+}
+
+###########################################################################
+#
+# Build node_modules which need to be native builded.
+#
+nativeBuild() {
+  echo ${NativeModules[@]} | xargs -P ${NUM_PROCESS} -n 1 npm rebuild
+}
+
+###########################################################################
+#
+# Build node_modules which can be cross builded.
+#
+crossBuild() {
+  readInstalled
+  local crossModules=();
+  for name in ${InstalledModules[@]}; do
+    local isCross="true"
+    for filter in ${NativeModules[@]}; do
+      if [ "${name}" = "${filter}" ]; then
+        isCross="false"
+        break
+      fi
+    done
+    if [ "${isCross}" = "true" ]; then
+        crossModules+=(${name})
+    fi
+  done
+  npm rebuild ${crossModules[@]} "$@"
+}
+
+# node_modules which need to be native builded.
+NativeModules=();
+markNativeBuild gifsicle
+markNativeBuild mozjpeg
+markNativeBuild optipng-bin
+markNativeBuild pngquant-bin
+markNativeBuild cwebp-bin
+
+main () {
+  local cmd="$1"
+  shift
+  case $cmd in
+    cross)
+      crossBuild "$@"
+      ;;
+    native)
+      nativeBuild
+      ;;
+    * )
+      usage
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Now, we can not [build Raspberry Pi gateway on the host](https://github.com/mozilla-iot/wiki/wiki/Building-the-Raspberry-Pi-gateway-on-the-host), because installing [`pngquant-bin`](https://github.com/imagemin/pngquant-bin) dose not use node-gyp and environment variable to build from source.

This pull request propose that all process work with qemu-user to install node_modules.

Usage
```
sudo apt install docker.io apparmor apparmor-utils qemu-user-static wget

sudo docker run sdthirlwall/raspberry-pi-cross-compiler > ~/bin/rpxc
chmod +x ~/bin/rpxc

mkdir docker-moziot
cd docker-moziot
mkdir -p OpenZWave
cd OpenZWave
git clone https://github.com/OpenZWave/open-zwave.git
cd ..
git clone https://github.com/mozilla-iot/gateway

docker build -t your_image_name gateway/image/builder/
rpxc --image your_image_name gateway/image/build-gateway.sh
```