### PR TITLE
Use eval sourceMap on js files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,10 @@ const pluginsWeb = [
     test: /\.js$/,
     sourceMap: true,
   }),
+  new webpack.SourceMapDevToolPlugin({
+    test: /\.css$/,
+    filename: '[file].map',
+  }),
   new MiniCssExtractPlugin({
     filename: 'bundle/[hash]-[name].css',
   }),
@@ -246,7 +250,7 @@ const webpackWeb = {
     fs: 'empty',
   },
   plugins: pluginsWeb,
-  devtool: 'source-map',
+  devtool: 'eval',
 };
 
 module.exports = [


### PR DESCRIPTION
Fix https://github.com/mozilla-iot/gateway/issues/974

We should use `eval` type sourcemap in order to show correct `err.stack` on console.
Probably, Firefox only supports `eval` type sourcemap on console.

I generate some sourceMap types.
* sourcemap // separate files .js and .map
* inline-sourcemap
* eval

## Firefox
I can use debugger(set breakpoint ) with any sourcemap types, but I can only see correct `err.stack` with [`eval` type sourcemap](https://survivejs.com/webpack/building/source-maps/#devtool-eval-) on console.

## Chrome
I can use debugger with any sourceMap types, and I can see correct `err.stack` with any sourcemap types.