### PR TITLE
Remove sleep from rule engine tests

### DIFF
--- a/src/rules-engine/Rule.js
+++ b/src/rules-engine/Rule.js
@@ -24,9 +24,9 @@ class Rule {
   /**
    * Begin executing the rule
    */
-  start() {
-    this.trigger.start();
+  async start() {
     this.trigger.on(Events.STATE_CHANGED, this.onTriggerStateChanged);
+    await this.trigger.start();
   }
 
   /**

--- a/src/test/browser/things-view/test-utils.js
+++ b/src/test/browser/things-view/test-utils.js
@@ -47,32 +47,6 @@ module.exports.setProperty = async function(id, property, value) {
   return res.body[property];
 };
 
-module.exports.waitForExpect = function(expect) {
-  return new Promise((resolve, reject) => {
-    let wait = 2500;
-    const interval = 500;
-    const sleep = (ms) => {
-      return new Promise((resolve) => setTimeout(() => resolve(), ms));
-    };
-    const retry = async () => {
-      try {
-        await expect();
-        resolve();
-        return;
-      } catch (err) {
-        wait -= interval;
-        if (wait <= 0) {
-          reject(err);
-          return;
-        }
-        await sleep(interval);
-        retry();
-      }
-    };
-    retry();
-  });
-};
-
 let stepNumber = 0;
 module.exports.saveStepScreen = async function(step) {
   let stepStr = stepNumber.toString();

--- a/src/test/browser/things-view/thing-test.js
+++ b/src/test/browser/things-view/thing-test.js
@@ -3,8 +3,9 @@ const {
   addThing,
   getProperty,
   setProperty,
-  waitForExpect,
 } = require('./test-utils');
+
+const {waitForExpect} = require('../../expect-utils');
 const ThingsPage = require('../page-object/things-page');
 
 const STATIC_JS_PATH = '../../../../static/js';

--- a/src/test/expect-utils.js
+++ b/src/test/expect-utils.js
@@ -1,0 +1,25 @@
+module.exports.waitForExpect = function(expect) {
+  return new Promise((resolve, reject) => {
+    let wait = 2500;
+    const interval = 500;
+    const sleep = (ms) => {
+      return new Promise((resolve) => setTimeout(() => resolve(), ms));
+    };
+    const retry = async () => {
+      try {
+        await expect();
+        resolve();
+        return;
+      } catch (err) {
+        wait -= interval;
+        if (wait <= 0) {
+          reject(err);
+          return;
+        }
+        await sleep(interval);
+        retry();
+      }
+    };
+    retry();
+  });
+};

--- a/src/test/rules-engine/index-test.js
+++ b/src/test/rules-engine/index-test.js
@@ -1,5 +1,6 @@
 const {server, chai, mockAdapter} = require('../common');
 const Settings = require('../../models/settings');
+const {waitForExpect} = require('../expect-utils');
 
 const pFinal = require('../promise-final');
 const {
@@ -509,19 +510,22 @@ describe('rules engine', function() {
     const ruleId = res.body.id;
 
     await setOn(thingLight1.id, false);
-    await sleep(200);
-    expect(await getOn(thingLight2.id)).toEqual(false);
+    await waitForExpect(async () => {
+      expect(await getOn(thingLight2.id)).toEqual(false);
+    });
 
     await setOn(thingLight2.id, true);
     expect(await getOn(thingLight2.id)).toEqual(true);
 
     await setOn(thingLight1.id, false);
-    await sleep(200);
-    expect(await getOn(thingLight2.id)).toEqual(false);
+    await waitForExpect(async () => {
+      expect(await getOn(thingLight2.id)).toEqual(false);
+    });
 
     await setOn(thingLight1.id, true);
-    await sleep(200);
-    expect(await getOn(thingLight2.id)).toEqual(true);
+    await waitForExpect(async () => {
+      expect(await getOn(thingLight2.id)).toEqual(true);
+    });
 
     await deleteRule(ruleId);
   });
@@ -536,23 +540,23 @@ describe('rules engine', function() {
     expect(res.body).toHaveProperty('id');
     const ruleId = res.body.id;
 
-    await sleep(200);
-
-    Events.add(new Event('surge',
-                         'oh no there is too much electricity',
-                         thingLight1.id));
-
-    await sleep(200);
-
-    res = await chai.request(server)
-      .get(`${Constants.THINGS_PATH}/${thingLight1.id
-      }${Constants.ACTIONS_PATH}`)
-      .set('Accept', 'application/json')
-      .set(...headerAuth(jwt));
-    expect(res.status).toEqual(200);
-    expect(Array.isArray(res.body)).toBeTruthy();
-    expect(res.body.length).toEqual(1);
-    expect(res.body[0]).toHaveProperty('blink');
+    await waitForExpect(async () => {
+      Events.add(new Event('surge',
+                           'oh no there is too much electricity',
+                           thingLight1.id));
+      sleep(200);
+      res = await chai.request(server)
+        .get(`${Constants.THINGS_PATH}/${thingLight1.id
+        }${Constants.ACTIONS_PATH}`)
+        .set('Accept', 'application/json')
+        .set(...headerAuth(jwt));
+      expect(res.status).toEqual(200);
+      expect(Array.isArray(res.body)).toBeTruthy();
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      res.body.forEach((e) => {
+        expect(e).toHaveProperty('blink');
+      });
+    });
 
     // dispatch event get action
     await deleteRule(ruleId);
@@ -569,14 +573,16 @@ describe('rules engine', function() {
     const ruleId = res.body.id;
 
     await setOn(thingLight1.id, true);
-    await sleep(200);
-    expect(await getOn(thingLight2.id)).toEqual(true);
-    expect(await getOn(thingLight3.id)).toEqual(true);
+    await waitForExpect(async () => {
+      expect(await getOn(thingLight2.id)).toEqual(true);
+      expect(await getOn(thingLight3.id)).toEqual(true);
+    });
 
     await setOn(thingLight1.id, false);
-    await sleep(200);
-    expect(await getOn(thingLight2.id)).toEqual(false);
-    expect(await getOn(thingLight3.id)).toEqual(false);
+    await waitForExpect(async () => {
+      expect(await getOn(thingLight2.id)).toEqual(false);
+      expect(await getOn(thingLight3.id)).toEqual(false);
+    });
 
     await deleteRule(ruleId);
   });


### PR DESCRIPTION
I failed rule-engin tests sometimes, because using fixed time sleep to wait async process.
This PR replace `sleep` with `waitForExpect ` to observe conditions multitimes.