### PR TITLE
package: Add le-acme-core module

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
     "jsonwebtoken": "^8.1.0",
+    "le-acme-core": "^2.1.3",
     "le-challenge-dns": "^2.3.2",
     "mini-css-extract-plugin": "^0.4.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
To prevent observed logged failure on
 "Choose a secure web address for your gateway:" page:

  Error: Cannot find module 'le-acme-core'

Bug: https://github.com/mozilla-iot/gateway/issues/928
Signed-off-by: Philippe Coval <rzr@users.sf.net>