### PR TITLE
The properties on thing-view reflects the value which PUT property API returns

### DIFF
--- a/src/addons-test/mock-adapter/mock-adapter.js
+++ b/src/addons-test/mock-adapter/mock-adapter.js
@@ -15,6 +15,9 @@ class MockProperty extends Property {
     super(device, name, propertyDescription);
     this.unit = propertyDescription.unit;
     this.description = propertyDescription.description;
+    this.readOnly = propertyDescription.hasOwnProperty('readOnly') ?
+      propertyDescription.readOnly :
+      false;
     this.setCachedValue(propertyDescription.value);
     this.device.notifyPropertyChanged(this);
   }
@@ -28,6 +31,10 @@ class MockProperty extends Property {
    */
   setValue(value) {
     return new Promise((resolve, reject) => {
+      if (this.readOnly) {
+        reject();
+        return;
+      }
       super.setValue(value).then((updatedValue) => {
         resolve(updatedValue);
         this.device.notifyPropertyChanged(this);

--- a/src/addons-test/mock-adapter/mock-adapter.js
+++ b/src/addons-test/mock-adapter/mock-adapter.js
@@ -15,9 +15,6 @@ class MockProperty extends Property {
     super(device, name, propertyDescription);
     this.unit = propertyDescription.unit;
     this.description = propertyDescription.description;
-    this.readOnly = propertyDescription.hasOwnProperty('readOnly') ?
-      propertyDescription.readOnly :
-      false;
     this.setCachedValue(propertyDescription.value);
     this.device.notifyPropertyChanged(this);
   }
@@ -31,7 +28,7 @@ class MockProperty extends Property {
    */
   setValue(value) {
     return new Promise((resolve, reject) => {
-      if (this.readOnly) {
+      if (/^rejectProperty/.test(this.name)) {
         reject();
         return;
       }

--- a/src/test/browser/things-view/thing-test.js
+++ b/src/test/browser/things-view/thing-test.js
@@ -161,21 +161,18 @@ describe('Thing', () => {
       name: 'foofoo',
       type: 'thing',
       properties: {
-        numberProp: {
+        rejectPropertyNum: {
           value: 10,
           type: 'number',
           unit: 'percent',
-          readOnly: true,
         },
-        stringProp: {
+        rejectPropertyStr: {
           value: 'bar',
           type: 'string',
-          readOnly: true,
         },
-        booleanProp: {
+        rejectPropertyBool: {
           value: true,
           type: 'boolean',
-          readOnly: true,
         },
       },
     };
@@ -204,7 +201,7 @@ describe('Thing', () => {
     expect(numberValue).toEqual(10);
     await numberProps[0].setValue(20);
     await waitForExpect(async () => {
-      numberValue = await getProperty(desc.id, 'numberProp');
+      numberValue = await getProperty(desc.id, 'rejectPropertyNum');
       expect(numberValue).toEqual(10);
       numberValue = await numberProps[0].getValue();
       expect(numberValue).toEqual(10);
@@ -216,7 +213,7 @@ describe('Thing', () => {
     expect(stringValue).toEqual('bar');
     await stringProps[0].setValue('foo');
     await waitForExpect(async () => {
-      stringValue = await getProperty(desc.id, 'stringProp');
+      stringValue = await getProperty(desc.id, 'rejectPropertyStr');
       expect(stringValue).toEqual('bar');
       stringValue = await stringProps[0].getValue();
       expect(stringValue).toEqual('bar');

--- a/static/js/color-light.js
+++ b/static/js/color-light.js
@@ -206,10 +206,12 @@ ColorLight.prototype.setColor = function(color) {
     }),
   }).then((response) => {
     if (response.status === 200) {
-      this.updateColor(color);
+      return response.json();
     } else {
-      console.error(`Status ${response.status} trying to set color`);
+      throw new Error(`Status ${response.status} trying to set color`);
     }
+  }).then((json) => {
+    this.updateColor(json.color);
   }).catch(function(error) {
     console.error(`Error trying to set color: ${error}`);
   });
@@ -248,11 +250,13 @@ ColorLight.prototype.setColorTemperature = function(temperature) {
     }),
   }).then((response) => {
     if (response.status === 200) {
-      this.updateColorTemperature(temperature);
+      return response.json();
     } else {
-      console.error(
+      throw new Error(
         `Status ${response.status} trying to set color temperature`);
     }
+  }).then((json) => {
+    this.updateColorTemperature(json.colorTemperature);
   }).catch(function(error) {
     console.error(`Error trying to set color temperature: ${error}`);
   });

--- a/static/js/multi-level-switch.js
+++ b/static/js/multi-level-switch.js
@@ -158,10 +158,12 @@ MultiLevelSwitch.prototype.setLevel = function(level) {
     }),
   }).then((response) => {
     if (response.status === 200) {
-      this.updateLevel(level);
+      return response.json();
     } else {
-      console.error(`Status ${response.status} trying to set level`);
+      throw new Error(`Status ${response.status} trying to set level`);
     }
+  }).then((json) => {
+    this.updateLevel(json.level);
   }).catch(function(error) {
     console.error(`Error trying to set level: ${error}`);
   });

--- a/static/js/on-off-switch.js
+++ b/static/js/on-off-switch.js
@@ -130,13 +130,15 @@ OnOffSwitch.prototype.turnOn = function() {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
-  }).then((function(response) {
+  }).then((response) => {
     if (response.status == 200) {
-      this.onPropertyStatus({on: true});
+      return response.json();
     } else {
-      console.error(`Status ${response.status} trying to turn on switch`);
+      throw new Error(`Status ${response.status} trying to turn on switch`);
     }
-  }).bind(this)).catch(function(error) {
+  }).then((json) => {
+    this.onPropertyStatus(json);
+  }).catch((error) => {
     console.error(`Error trying to turn on switch: ${error}`);
   });
 };
@@ -158,13 +160,15 @@ OnOffSwitch.prototype.turnOff = function() {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
-  }).then((function(response) {
+  }).then((response) => {
     if (response.status == 200) {
-      this.onPropertyStatus({on: false});
+      return response.json();
     } else {
-      console.error(`Status ${response.status} trying to turn off switch`);
+      throw new Error(`Status ${response.status} trying to turn off switch`);
     }
-  }).bind(this)).catch(function(error) {
+  }).then((json) => {
+    this.onPropertyStatus(json);
+  }).catch((error) => {
     console.error(`Error trying to turn off switch: ${error}`);
   });
 };

--- a/static/js/smart-plug.js
+++ b/static/js/smart-plug.js
@@ -199,10 +199,12 @@ SmartPlug.prototype.setLevel = function(level) {
     }),
   }).then((response) => {
     if (response.status === 200) {
-      this.updateLevel(level);
+      return response.json();
     } else {
-      console.error(`Status ${response.status} trying to set level`);
+      throw new Error(`Status ${response.status} trying to set level`);
     }
+  }).then((json) => {
+    this.updateLevel(json.level);
   }).catch(function(error) {
     console.error(`Error trying to set level: ${error}`);
   });

--- a/static/js/unknown-thing.js
+++ b/static/js/unknown-thing.js
@@ -124,10 +124,12 @@ UnknownThing.prototype.setProperty = function(name, value) {
     }),
   }).then((response) => {
     if (response.status === 200) {
-      this.updateProperty(name, value);
+      return response.json();
     } else {
-      console.error(`Status ${response.status} trying to set ${name}`);
+      throw new Error(`Status ${response.status} trying to set ${name}`);
     }
+  }).then((json) => {
+    this.updateProperty(name, json[name]);
   }).catch((error) => {
     console.error(`Error trying to set ${name}: ${error}`);
   });


### PR DESCRIPTION
Fixes #972 

* The `propertyChanged` message is sometimes not reached UI, because creating websocket connection is asynchronous with displaying thing-detail-view.
* Even if `notifyPropertyChanged` is called while reject `setValue`, the `propertyChanged` message sometimes reaches UI  earlier than `PUT property API` response.