### PR TITLE
Fix issue where add-ons could fail to restart.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -738,7 +738,11 @@ class AddonManager extends EventEmitter {
     }
 
     this.addonsLoaded = false;
-    return Promise.all(unloadPromises);
+    return Promise.all(unloadPromises).then(() => {
+      if (this.pluginServer) {
+        this.pluginServer.shutdown();
+      }
+    });
   }
 
   /**

--- a/src/plugin/plugin-server.js
+++ b/src/plugin/plugin-server.js
@@ -115,9 +115,10 @@ class PluginServer {
    */
   unregisterPlugin(pluginId) {
     this.plugins.delete(pluginId);
-    if (this.plugins.size == 0) {
-      this.ipcSocket.close();
-    }
+  }
+
+  shutdown() {
+    this.ipcSocket.close();
   }
 }
 


### PR DESCRIPTION
If only one add-on was loaded, and then was disabled, the IPC
socket would be shut down. Subsequent add-on loads would then
fail.

Fixes mozilla-iot/thing-url-adapter#42