### PR TITLE
Load javascript on local token service view

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,6 +125,7 @@ const webpackWeb = {
     'app.js': ['./static/js/check-user.js', './static/js/app.js'],
     'create-user.js': ['./static/js/create-user.js'],
     'login.js': ['./static/js/check-user.js', './static/js/login.js'],
+    'check-user.js': ['./static/js/check-user.js'],
     'authorize.js': ['./static/js/check-user.js', './static/js/authorize.js'],
     'setup_subdomain.js': ['./static/js/setup_subdomain.js'],
     buildCss: [


### PR DESCRIPTION
The Gateway display nothing on local token service view, because `check-user.js` is not loaded.
This degrade is caused by my mistake on https://github.com/mozilla-iot/gateway/pull/1035