### PR TITLE
install: Add policykit-1 for systemd

### DIFF
--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -55,6 +55,7 @@ sudo apt install -y \
   libtool \
   libudev-dev \
   libusb-1.0-0-dev \
+  policykit-1 \
   python-pip \
   python3-pip \
   sqlite3


### PR DESCRIPTION
Without this systemd can't stop or restart other services

Observed issue was:

   sudo systemctl stop ${unit}.service
   Failed to stop ${unit}.service: \
   The name org.freedesktop.PolicyKit1 \
   was not provided by any .service files

Change-Id: I3ebfb93f7198d907f54166e4d46a36d94a3dc557
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>