### PR TITLE
Tweak domain settings UI to match mockups

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -43,7 +43,7 @@ module.exports = {
         localControl: {
           mdnsServiceType: "http",
           mdnsServiceName: "Mozilla IoT Gateway",
-          mdnsServiceDomain: "gateway",
+          mdnsServiceDomain: "mygateway",
 
           mdnsTxt: {
             desc: "Web of Things gateway",

--- a/config/default.js
+++ b/config/default.js
@@ -43,10 +43,10 @@ module.exports = {
         localControl: {
           mdnsServiceType: "http",
           mdnsServiceName: "Mozilla IoT Gateway",
-          mdnsServiceDomain: "MozillaIoTGateway",
+          mdnsServiceDomain: "gateway",
 
           mdnsTxt: {
-            desc: "A local IoT Gateway",
+            desc: "Web of Things gateway",
             protocol: "http, https, Web Sockets",
             power: "6 watts",
           },

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -201,7 +201,7 @@
   display: none;
 }
 
-.experiment-item, .update-item, .authorization-item, .domain-item {
+.experiment-item, .update-item, .authorization-item {
   display: block;
   margin: 1rem 0;
   font-size: 1.8rem;
@@ -219,7 +219,8 @@
 .adapter-item,
 .addon-item,
 .authorization-item,
-.discovered-addon-item {
+.discovered-addon-item,
+.domain-item {
   display: block;
   font-size: 1.8rem;
   list-style-type: none;
@@ -231,8 +232,13 @@
 .user-item,
 .adapter-item,
 .addon-item,
-.authorization-item {
+.authorization-item,
+.domain-item {
   background-color: #5288af;
+}
+
+.domain-item {
+  padding: 2rem;
 }
 
 .discovered-addon-item {
@@ -281,16 +287,31 @@
   color: #ccc;
 }
 
-.domain-settings-description-small {
-  display: block;
-  color: #ccc;
-  font-size: 1.4rem
+.domain-settings-error {
+  color: #ff9955;
+  font-size: 1.4rem;
+  padding: 0 0 1rem 0;
 }
 
-.domain-settings-error {
-  color: orange;
-  font-size: 1.2rem;
-  padding: 1rem 0;
+.domain-settings-error.hidden {
+  display: none;
+}
+
+#domain-settings-local-label {
+  display: block;
+}
+
+#domain-settings-local-name {
+  display: inline-block;
+  margin: 1.5rem auto;
+}
+
+#domain-settings-local-update {
+  display:block;
+}
+
+#domain-settings-tunnel-name {
+  font-size: 1.4rem;
 }
 
 .addon-settings-author {
@@ -328,8 +349,7 @@
 .addon-discovery-settings-add,
 .addon-discovery-settings-installing,
 .addon-discovery-settings-install-failed,
-.addon-settings-remove,
-.domain-settings-save {
+.addon-settings-remove {
   background-size: 2rem;
   background-repeat: no-repeat;
   background-position: 0.5em;
@@ -344,7 +364,8 @@
 .addon-settings-update,
 .addon-settings-disable,
 .addon-settings-enable,
-.addon-settings-remove {
+.addon-settings-remove,
+.domain-settings-update {
   background-color: #48779a;
 }
 
@@ -448,6 +469,12 @@
   background-position: 0 -9rem;
 }
 
+#domain-settings-local-checkbox + label:before {
+  float: none;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+}
+
 #floorplan-experiment-item {
   background-image: url('../optimized-images/floorplan-icon.png');
 }
@@ -545,7 +572,7 @@
 }
 
 .user-form .error {
-  color: orange;
+  color: #ff9955;
 }
 
 .user-form input[type="text"],

--- a/static/index.html
+++ b/static/index.html
@@ -63,26 +63,23 @@
         <ul>
           <li class="domain-item">
             <input id="domain-settings-local-checkbox" name="domain-settings"
-                   class="experiment-checkbox" type="checkbox">
-            <label for="domain-settings-local-checkbox">
-              Local access (Using Service Discovery)
+              class="experiment-checkbox" type="checkbox">
+            <label id="domain-settings-local-label"
+              for="domain-settings-local-checkbox">
+              Local Access
             </label>
-            <p class="domain-settings-description-small">
-              Type the domain name you wish to use for the gateway below and
-              click the 'update host name' button.
-            </p>
             <input type="text" id="domain-settings-local-name" name="gateway"
-                   placeholder="gateway">
-            &nbsp;. local
+                   placeholder="gateway" />
+            <span id="domain-settings-local-suffix">.local</span>
             <div id="domain-settings-error" class="domain-settings-error hidden"></div>
-            <button id="settings-domain-local-update" class="text-button"
+            <button id="domain-settings-local-update" class="domain-settings-update text-button"
                     type="submit">
               Update host name
             </button>
           </li>
           <li class="domain-item">
             <p class="domain-settings-container">
-              Remote Access (Uses Mozilla servers: mozilla-iot.org)
+              Remote Access
             </p>
             <p id="domain-settings-tunnel-name" class="domain-settings-container">
               &nbsp;. mozilla-iot.org

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -160,7 +160,7 @@ const SettingsScreen = {
     };
 
     const addDomainLocalButton =
-      document.getElementById('settings-domain-local-update');
+      document.getElementById('domain-settings-local-update');
     addDomainLocalButton.addEventListener('click', () => {
       this.onLocalDomainClick();
     });


### PR DESCRIPTION
Some slight UI tweaks to match the UX specification at https://docs.google.com/presentation/d/1rMeg6hep8JQflqwbiNIbhSoK9StCeVZ2npphmQHKda4/edit#slide=id.g3c095fbf0e_0_0

There's one remaining issue which I'll file a follow-up for.

Also changes default mDNS host name back to gateway.local to match all our documentation and blog posts.