### PR TITLE
Use replace instead of set to not mess with browser's back button

### DIFF
--- a/static/js/check-user.js
+++ b/static/js/check-user.js
@@ -36,7 +36,7 @@ function redirectUnauthed() {
     }
 
     if (window.location.pathname !== url.split('?')[0]) {
-      window.location.href = url;
+      window.location.replace(url);
     }
   });
 }


### PR DESCRIPTION
Fix #1072