### PR TITLE
Fix issue with back button.

### DIFF
--- a/static/js/action-detail.js
+++ b/static/js/action-detail.js
@@ -29,8 +29,10 @@ ActionDetail.prototype.view = function() {
   let inputLink, disabled, extraClass;
   if (typeof this.input !== 'undefined') {
     const href = `${window.location.pathname}/actions/${this.name}`;
+    const referrer = encodeURIComponent(window.location.pathname);
     inputLink =
-      `<a href="${encodeURI(href)}" class="action-input-link">...</a>`;
+      `<a href="${encodeURI(href)}?referrer=${referrer}"
+          class="action-input-link">...</a>`;
     extraClass = 'advanced-action-button';
 
     if (typeof this.input === 'object' &&

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -77,7 +77,8 @@ const App = {
     const events = context.pathname.split('/').pop() === 'events';
     ThingsScreen.show(context.params.thingId || null,
                       context.params.actionName || null,
-                      events);
+                      events,
+                      context.querystring);
     this.selectView('things');
   },
 

--- a/static/js/thing.js
+++ b/static/js/thing.js
@@ -59,7 +59,8 @@ const Thing = function(description, format, options) {
   // Parse base URL of Thing
   if (description.href) {
     this.href = new URL(description.href, App.ORIGIN);
-    this.eventsHref = `${this.href.pathname}/events`;
+    this.eventsHref = `${this.href.pathname}/events?referrer=${
+      encodeURIComponent(this.href.pathname)}`;
     this.id = this.href.pathname.split('/').pop();
 
     const wsHref = this.href.href.replace(/^http/, 'ws');

--- a/static/js/things.js
+++ b/static/js/things.js
@@ -58,8 +58,8 @@ const ThingsScreen = {
    * @param {String} actionName Optional action input form to show.
    * @param {Boolean} events Whether or not to display the events screen.
    */
-  show: function(thingId, actionName, events) {
-    const params = new URLSearchParams(window.location.search);
+  show: function(thingId, actionName, events, queryString) {
+    const params = new URLSearchParams(`?${queryString || ''}`);
     if (params.has('referrer')) {
       this.backRef = params.get('referrer');
     } else {


### PR DESCRIPTION
page.js updates window.location AFTER routing, which is why we
no longer use it.

STR:
1. Add Virtual Actions & Events Thing
2. Navigate to the thing's actions or events page
3. Click the back button

Expected:
Go back to thing detail page.

Actual:
Go back to things list.