### PR TITLE
Fix conflicting addon status enabled.

### DIFF
--- a/static/js/installed-addon.js
+++ b/static/js/installed-addon.js
@@ -179,9 +179,12 @@ InstalledAddon.prototype.handleRemove = function() {
  */
 InstalledAddon.prototype.handleToggle = function(e) {
   const button = e.target;
-  this.enabled = !this.enabled;
-  API.setAddonSetting(this.name, this.enabled)
+  const enabled = !this.enabled;
+  API.setAddonSetting(this.name, enabled)
     .then(() => {
+      this.enabled = enabled;
+      const addon = this.installedAddonsMap.get(this.name);
+      addon.moziot.enabled = enabled;
       if (this.enabled) {
         button.innerText = 'Disable';
         button.classList.remove('addon-settings-enable');


### PR DESCRIPTION
1. An Add-on disable on setting page.
2. Move other page.
3. Move back setting page.
Then displaying Add-on status as enabled.