### PR TITLE
Add some RPi libraries supporting Python Bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ The following is required in order to let node use the Bluetooth adapter.
 $ sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
 ```
 
+### Install Bluetooth and BT Low Energy support libraries (Raspberry Pi Only)
+
+The following are required in order to install the Python modules that support Bluetooth
+
+```
+$ sudo apt-get install libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev 
+```
+
 ### Install libusb and libudev (Linux only)
 
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following is required in order to let node use the Bluetooth adapter.
 $ sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
 ```
 
-### Install Bluetooth and BT Low Energy support libraries (Raspberry Pi Only)
+### Install Bluetooth and BT Low Energy support libraries (Linux only)
 
 The following are required in order to install the Python modules that support Bluetooth
 

--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -49,7 +49,7 @@ sudo apt install -y \
   dnsmasq \
   git \
   hostapd \
-  libboost-pythón-dev \
+  libboost-python-dev \
 ´ libboost-thread-dev \
   libbluetooth-dev \
   libffi-dev \

--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -50,7 +50,7 @@ sudo apt install -y \
   git \
   hostapd \
   libboost-python-dev \
-´ libboost-thread-dev \
+  libboost-thread-dev \
   libbluetooth-dev \
   libffi-dev \
   libglib2.0-dev \

--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -49,7 +49,11 @@ sudo apt install -y \
   dnsmasq \
   git \
   hostapd \
+  libboost-pythón-dev \
+´ libboost-thread-dev \
+  libbluetooth-dev \
   libffi-dev \
+  libglib2.0-dev \
   libnanomsg-dev \
   libnanomsg4 \
   libtool \


### PR DESCRIPTION
I only install the libraries.
The Python modules can be installed by the adapter that needs them.