### PR TITLE
view: Set token id to token node

### DIFF
--- a/src/views/local-token-service.mustache
+++ b/src/views/local-token-service.mustache
@@ -32,7 +32,7 @@
         Your local token is this <a href="https://jwt.io/">JSON Web Token</a>:
         <br/>
         <br/>
-        <code>{{token}}</code>
+        <code id="token">{{token}}</code>
         <br/>
         Use it with <a
         href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization">Bearer-type


### PR DESCRIPTION
It will be easier to scrape the token value:

  document.getElementById('token').textContent

Alternativly token can be retrived using this XPATH query:

  /html/body/section/div[2]/code/text()

As used in "webthings-webapp" project.

Origin: https://github.com/TizenTeam/gateway
Change-Id: Icef244371620e6a5b714f7ef2624c2393e314ac6
Signed-off-by: Philippe Coval <p.coval@samsung.com>