### PR TITLE
security: post OAuth token to client webapps if any

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -74,5 +74,6 @@ module.exports = {
       ssid_base: 'WebThings Gateway',
     },
   },
+  oauthPostToken: false,
   oauthTestClients: false,
 };

--- a/src/controllers/oauth_controller.ts
+++ b/src/controllers/oauth_controller.ts
@@ -12,6 +12,7 @@ import * as express from 'express';
 import { URL } from 'url';
 import * as assert from 'assert';
 const JSONWebToken = require('../models/jsonwebtoken');
+const config = require('config');
 import * as Database from '../db';
 import {
   scopeValidSubset, Scope, ScopeAccess, ScopeRaw, ClientId, ClientRegistry
@@ -265,6 +266,7 @@ OAuthController.get('/local-token-service', async (request: express.Request, res
   let token = await handleAccessTokenRequest(request, response);
   if (token) {
     response.render('local-token-service', {
+      oauthPostToken: config.get('oauthPostToken'),
       token: token.access_token
     });
   }

--- a/src/router.js
+++ b/src/router.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+const config = require('config');
 const compression = require('compression');
 const Constants = require('./constants');
 const express = require('express');
@@ -43,7 +44,11 @@ const Router = {
       }
 
       // Disable embedding
-      response.set('Content-Security-Policy', 'frame-ancestors \'none\'');
+      response.set('Content-Security-Policy',
+                   config.get('oauthPostToken') ?
+                     'frame-ancestors filesystem:' :
+                     'frame-ancestors \'none\''
+      );
 
       next();
     });

--- a/src/views/local-token-service.handlebars
+++ b/src/views/local-token-service.handlebars
@@ -123,6 +123,18 @@ let text = client.get("<span class="origin">https://gateway.local</span>/things"
         </div>
       </div>
     </section>
+    <script>
+if ({{oauthPostToken}}) {
+  window.addEventListener("message", function(ev) {
+   if (ev.origin !== 'file://') {
+     return;
+   }
+   if (ev.data.message === "token") {
+      ev.source.postMessage({ message: { token: "{{token}}" }}, "*");
+    }
+  });
+}
+    </script>
   </body>
 </html>
 


### PR DESCRIPTION
When loaded from window.opener CORS is blocked by default,
so this is workaraounding security issues like:

  Uncaught DOMException: Blocked a frame with origin (...)
  from accessing a cross-origin frame. at (...)

For any security concern this change can be reverted anytime.

Change-Id: I42af71ae822491150c019cff9688356b1a0e2532
Signed-off-by: Philippe Coval <p.coval@samsung.com>