### PR TITLE
Use setProperty instead of handleClick to work with Thing

### DIFF
--- a/static/js/property-detail/on-off.js
+++ b/static/js/property-detail/on-off.js
@@ -21,14 +21,9 @@ class OnOffDetail {
   }
 
   attach() {
-    this.onOffSwitch = this.thing.element.querySelector(`#${this.id}`);
-    if (typeof this.thing.handleClick === 'function') {
-      const handleClick = Utils.debounce(
-        500,
-        this.thing.handleClick.bind(this.thing)
-      );
-      this.onOffSwitch.addEventListener('change', handleClick);
-    }
+    this.input = this.thing.element.querySelector(`#${this.id}`);
+    const setOnOff = Utils.debounce(500, this.set.bind(this));
+    this.input.addEventListener('change', setOnOff);
   }
 
   view() {
@@ -42,7 +37,11 @@ class OnOffDetail {
 
   update() {
     const on = this.thing.properties[this.name];
-    this.onOffSwitch.checked = on;
+    this.input.checked = on;
+  }
+
+  set() {
+    this.thing.setProperty(this.name, this.input.checked);
   }
 }
 


### PR DESCRIPTION
Fixes an issue where if a Thing had a property named "on" (or with the correct capability) it would create an OnOffProperty that would silently ignore all input due to the Thing's lack of the handleClick function.

This makes OnOffDetail work the same way as BooleanDetail while preserving the handleClick function  for its use in the component view. Future work could consolidate handleClick with the set() function.