### PR TITLE
oauth: Require class instead of import object

### DIFF
--- a/src/controllers/oauth_controller.ts
+++ b/src/controllers/oauth_controller.ts
@@ -11,7 +11,7 @@
 import * as express from 'express';
 import { URL } from 'url';
 import * as assert from 'assert';
-import * as JSONWebToken from '../models/jsonwebtoken';
+const JSONWebToken = require('../models/jsonwebtoken');
 import * as Database from '../db';
 import {
   scopeValidSubset, Scope, ScopeAccess, ScopeRaw, ClientId, ClientRegistry


### PR DESCRIPTION
My understanding only "Object" (class instances) can be imported,
for classes then require must be used.

Observed issue on node v10.6.0 (on fedora-24 ARMv7 on ARTIK7):

    ERROR in [at-loader] ./src/controllers/oauth_controller.ts:14:31
    TS2497: Module '"/home/rzr/gateway/src/models/jsonwebtoken"'
    resolves to a non-module entity
    and cannot be imported using this construct. Child

More insights at:

* https://tc39.github.io/ecma262/#sec-imports
* https://stackoverflow.com/questions/39415661/what-does-resolves-to-a-non-module-entity-and-cannot-be-imported-using-this

Change-Id: I7b9783001da15c7dde5d92b893570666493b828c
Signed-off-by: Philippe Coval <p.coval@samsung.com>