### PR TITLE
Allow python3 to use the Bluetooth adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Follow the directions from [NodeJS](https://nodejs.org) to install on your platf
 
 ### Set up Bluetooth permissions
 
-The following is required in order to let node use the Bluetooth adapter.
+The following is required in order to let node and python3 use the Bluetooth adapter.
 
 ```
 $ sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
+$ sudo setcap cap_net_raw+eip $(eval readlink -f `which python3`)
 ```
 
 ### Install Bluetooth and BT Low Energy support libraries (Linux only)

--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -73,8 +73,9 @@ export NVM_DIR="$HOME/.nvm"
 nvm install ${NODE_VERSION}
 nvm use ${NODE_VERSION}
 
-# Allow node to use the Bluetooth adapter
+# Allow node and python3 to use the Bluetooth adapter
 sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
+sudo setcap cap_net_raw+eip $(eval readlink -f `which python3`)
 
 npm install -g yarn
 

--- a/image/prepare-base-root.sh
+++ b/image/prepare-base-root.sh
@@ -11,8 +11,9 @@ export NVM_DIR="$HOME/.nvm"
 nvm install ${NODE_VERSION}
 nvm use ${NODE_VERSION}
 
-# Allow node to use the Bluetooth adapter
+# Allow node and python3 to use the Bluetooth adapter
 setcap cap_net_raw+eip $(eval readlink -f `which node`)
+setcap cap_net_raw+eip $(eval readlink -f `which python3`)
 
 # download and install the code
 wget https://github.com/mozilla-iot/gateway-wifi-setup/archive/master.zip

--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -39,9 +39,6 @@ export NVM_DIR="$HOME/.nvm"
 nvm install ${NODE_VERSION}
 nvm use ${NODE_VERSION}
 
-# Allow node to use the Bluetooth adapter
-sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
-
 # Install prequisite packages
 sudo apt install -y \
   autoconf \
@@ -72,7 +69,8 @@ sudo pip3 install "$_url"
 _url="git+https://github.com/mycroftai/adapt#egg=adapt-parser"
 sudo pip3 install "$_url"
 
-# Allow python3 to use the Bluetooth adapter
+# Allow node and python3 to use the Bluetooth adapter
+sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
 sudo setcap cap_net_raw+eip $(eval readlink -f `which python3`)
 
 git clone https://github.com/mozilla-iot/intent-parser "$HOME/mozilla-iot/intent-parser"

--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -72,6 +72,9 @@ sudo pip3 install "$_url"
 _url="git+https://github.com/mycroftai/adapt#egg=adapt-parser"
 sudo pip3 install "$_url"
 
+# Allow python3 to use the Bluetooth adapter
+sudo setcap cap_net_raw+eip $(eval readlink -f `which python3`)
+
 git clone https://github.com/mozilla-iot/intent-parser "$HOME/mozilla-iot/intent-parser"
 
 # Create the service file needed by systemctl


### PR DESCRIPTION
I would have thought that python inherited the capability from node (that's what the 'i' flag in +eip means), but it seems not to be the case.