### PR TITLE
Run all of webpack through cache-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 .DS_Store
 .nyc_output/
+.cache-loader/
 
 # Build artifacts
 /build

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "devDependencies": {
     "babel-eslint": "^8.2.3",
     "babel-plugin-dynamic-import-node": "^1.2.0",
+    "cache-loader": "^1.2.2",
     "chai": "^4.1.2",
     "chai-http": "^3.0.0",
     "codecov": "^3.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -198,7 +198,6 @@ const webpackWeb = {
         test: /\.css$/,
         include: path.resolve(__dirname, 'static'),
         use: [
-          'cache-loader',
           {
             loader: MiniCssExtractPlugin.loader,
           },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,11 @@ const webpackNode = {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'awesome-typescript-loader',
+        include: path.resolve(__dirname, 'src'),
+        use: [
+          'cache-loader',
+          'awesome-typescript-loader',
+        ],
       },
     ],
   },
@@ -165,7 +169,9 @@ const webpackWeb = {
     rules: [
       {
         test: /.\/static\/js\/.*\.js$/,
+        include: path.resolve(__dirname, 'static'),
         use: [
+          'cache-loader',
           {
             loader: 'babel-loader',
             query: {
@@ -190,7 +196,9 @@ const webpackWeb = {
       },
       {
         test: /\.css$/,
+        include: path.resolve(__dirname, 'static'),
         use: [
+          'cache-loader',
           {
             loader: MiniCssExtractPlugin.loader,
           },
@@ -204,19 +212,24 @@ const webpackWeb = {
       },
       {
         test: /\.html$/,
-        use: {
-          loader: 'html-loader',
-          options: {
-            attrs: ['img:src'],
-            root: path.join(__dirname, 'static'),
-            minimize: true,
+        use: [
+          'cache-loader',
+          {
+            loader: 'html-loader',
+            options: {
+              attrs: ['img:src'],
+              root: path.join(__dirname, 'static'),
+              minimize: true,
+            },
           },
-        },
+        ],
       },
       {
         test:
           /(?!\/uploads\/floorplan)\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
+        include: path.resolve(__dirname, 'static'),
         use: [
+          'cache-loader',
           {
             loader: 'url-loader',
             options: {
@@ -264,6 +277,7 @@ const webpackSW = {
     rules: [
       {
         test: /\.js$/,
+        include: path.resolve(__dirname, 'static'),
         use: ExtractTextPlugin.extract({
           use: 'raw-loader',
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,6 +2392,15 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cache-loader@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-1.2.2.tgz#6d5c38ded959a09cc5d58190ab5af6f73bd353f5"
+  dependencies:
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
+    neo-async "^2.5.0"
+    schema-utils "^0.4.2"
+
 cacheable-request@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
@@ -8675,7 +8684,7 @@ sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-schema-utils@^0.4.3, schema-utils@^0.4.4, schema-utils@^0.4.5:
+schema-utils@^0.4.2, schema-utils@^0.4.3, schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:


### PR DESCRIPTION
Reduces first load time from 2:49 to 2:19 and repeat load to 0:54. I'm continuing to look into other opportunities and it remains to be seen whether this persists in an image.

Notably, @dhylands, the rpi-image-builder script will have to be modified to run webpack once and bundle in the .cache-loader directory.