### PR TITLE
Run webpack during image build

### DIFF
--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -80,7 +80,7 @@ sudo setcap cap_net_raw+eip $(eval readlink -f `which python3`)
 npm install -g yarn
 
 # Build the node modules, cross compiling any native code.
-(cd ${GATEWAY}; yarn --ignore-scripts; npm rebuild --arch=${ARCH} --target_arch=arm)
+(cd ${GATEWAY}; yarn --ignore-scripts; npm rebuild --arch=${ARCH} --target_arch=arm; node_modules/.bin/webpack)
 
 set -x
 


### PR DESCRIPTION
This should get rpi-image-builder's output to include a prebuilt `.cache-loader` directory and reduce the first load times accordingly