### PR TITLE
Add 'exactly' to time trigger summary

### DIFF
--- a/static/js/rules/Rule.js
+++ b/static/js/rules/Rule.js
@@ -150,8 +150,15 @@ Rule.prototype.singleTriggerToHumanRepresentation = function(trigger, html) {
   }
 
   if (trigger.type === 'TimeTrigger') {
-    return `the time of day is ${
-      TimeTriggerBlock.utcToLocal(trigger.time)}`;
+    let text = `the time of day is`;
+    let firstEffect = this.effect;
+    if (firstEffect && firstEffect.type === 'MultiEffect') {
+      firstEffect = firstEffect.effects[0];
+    }
+    if (firstEffect && firstEffect.type === 'PulseEffect') {
+      text += ' exactly';
+    }
+    return `${text} ${TimeTriggerBlock.utcToLocal(trigger.time)}`;
   }
 
   if (trigger.type === 'EventTrigger') {


### PR DESCRIPTION
"If the time of day is 12:57" is unchanged
"While the time of day is 12:57" -> "While the time of day is exactly 12:57"

We could also just put the "exactly" in everywhere, I'm not sure what sounds best.
