### PR TITLE
Run post-upgrade in prepare-base

### DIFF
--- a/image/prepare-base.sh
+++ b/image/prepare-base.sh
@@ -277,4 +277,6 @@ END
 sudo chmod +x /etc/init.d/gateway-iptables.sh
 sudo update-rc.d gateway-iptables.sh defaults
 
+../tools/post-upgrade.sh
+
 echo "Done"


### PR DESCRIPTION
This allows them to share functionality. This also allows the generated
image to not run post-upgrade on its first boot. For example,
post-upgrade installs the thing-url-adapter which otherwise will be
missing (as far as I can tell).