### PR TITLE
ui: Allow multiple same properties in single thing

### DIFF
--- a/static/js/components/base-component.js
+++ b/static/js/components/base-component.js
@@ -23,6 +23,7 @@ class BaseComponent extends HTMLElement {
     }
 
     this.shadowRoot.appendChild(templateClone);
+    BaseComponent.count++;
   }
 
   connectedCallback() {
@@ -44,4 +45,5 @@ class BaseComponent extends HTMLElement {
   }
 }
 
+BaseComponent.count = 0;
 module.exports = BaseComponent;

--- a/static/js/components/property/boolean.js
+++ b/static/js/components/property/boolean.js
@@ -11,8 +11,10 @@
 
 const BaseComponent = require('../base-component');
 
-const template = document.createElement('template');
-template.innerHTML = `
+class BooleanProperty extends BaseComponent {
+  constructor() {
+    const template = document.createElement('template');
+    template.innerHTML = `
   <style>
     :host {
       display: inline-block;
@@ -73,23 +75,20 @@ template.innerHTML = `
   <div id="container" class="webthing-boolean-property-container">
     <div id="contents" class="webthing-boolean-property-contents">
       <form id="form" class="webthing-boolean-property-form">
-        <input type="checkbox" id="checkbox"
-          class="webthing-boolean-property-checkbox">
-        <label id="label" for="checkbox"
-          class="webthing-boolean-property-label">
+         <input type="checkbox" id="checkbox-${BaseComponent.count}"
+            class="webthing-boolean-property-checkbox"/>
+          <label class="webthing-boolean-property-label" for='checkbox-${BaseComponent.count}'>
         </label>
       </form>
     </div>
   </div>
   <div id="name" class="webthing-boolean-property-name"></div>
 `;
-
-class BooleanProperty extends BaseComponent {
-  constructor() {
     super(template);
-
-    this._input = this.shadowRoot.querySelector('#checkbox');
-    this._name = this.shadowRoot.querySelector('#name');
+    this._input =
+      this.shadowRoot.querySelector('.webthing-boolean-property-checkbox');
+    this._name =
+      this.shadowRoot.querySelector('.webthing-boolean-property-name');
 
     this._onClick = this.__onClick.bind(this);
     this._onKeyUp = this.__onKeyUp.bind(this);

--- a/static/js/components/property/switch.js
+++ b/static/js/components/property/switch.js
@@ -64,7 +64,7 @@ class SwitchProperty extends BaseComponent {
       transition: 0.1s;
     }
 
-      .webthing-switch-property-switch:checked + .webthing-switch-property-slider::after {
+    .webthing-switch-property-switch:checked + .webthing-switch-property-slider::after {
       transform: translate(3.65rem, 0.35rem);
     }
 
@@ -85,9 +85,9 @@ class SwitchProperty extends BaseComponent {
   <div id="container" class="webthing-switch-property-container">
     <div id="contents" class="webthing-switch-property-contents">
       <form>
-          <input type="checkbox" id="switch-${BaseComponent.count}"
+        <input type="checkbox" id="switch-${BaseComponent.count}"
           class="webthing-switch-property-switch">
-          <label id="slider-${BaseComponent.count}" for="switch-${BaseComponent.count}" class="webthing-switch-property-slider">
+        <label id="slider-${BaseComponent.count}" for="switch-${BaseComponent.count}" class="webthing-switch-property-slider">
         </label>
       </form>
       <div id="label" class="webthing-switch-property-label"></div>

--- a/static/js/components/property/switch.js
+++ b/static/js/components/property/switch.js
@@ -11,8 +11,10 @@
 
 const BaseComponent = require('../base-component');
 
-const template = document.createElement('template');
-template.innerHTML = `
+class SwitchProperty extends BaseComponent {
+  constructor() {
+    const template = document.createElement('template');
+    template.innerHTML = `
   <style>
     :host {
       display: inline-block;
@@ -62,7 +64,7 @@ template.innerHTML = `
       transition: 0.1s;
     }
 
-    .webthing-switch-property-switch:checked + #slider::after {
+      .webthing-switch-property-switch:checked + .webthing-switch-property-slider::after {
       transform: translate(3.65rem, 0.35rem);
     }
 
@@ -83,9 +85,9 @@ template.innerHTML = `
   <div id="container" class="webthing-switch-property-container">
     <div id="contents" class="webthing-switch-property-contents">
       <form>
-        <input type="checkbox" id="switch"
+          <input type="checkbox" id="switch-${BaseComponent.count}"
           class="webthing-switch-property-switch">
-        <label id="slider" for="switch" class="webthing-switch-property-slider">
+          <label id="slider-${BaseComponent.count}" for="switch-${BaseComponent.count}" class="webthing-switch-property-slider">
         </label>
       </form>
       <div id="label" class="webthing-switch-property-label"></div>
@@ -93,15 +95,14 @@ template.innerHTML = `
   </div>
   <div id="name" class="webthing-switch-property-name"></div>
 `;
-
-class SwitchProperty extends BaseComponent {
-  constructor() {
     super(template);
 
-    this._input = this.shadowRoot.querySelector('#switch');
-    this._name = this.shadowRoot.querySelector('#name');
-    this._label = this.shadowRoot.querySelector('#label');
-
+    this._input =
+      this.shadowRoot.querySelector('.webthing-switch-property-switch');
+    this._name =
+      this.shadowRoot.querySelector('.webthing-switch-property-name');
+    this._label =
+      this.shadowRoot.querySelector('.webthing-switch-property-label');
     this._onClick = this.__onClick.bind(this);
     this._onKeyUp = this.__onKeyUp.bind(this);
   }


### PR DESCRIPTION
Previously item ids were duplicated,
the observed consequence is that any click on widgets
is seen as click on 1st declared element.

For example, a thing with 2 switches is displayed correctly,
and click events are also triggered but will be "redirected"
to 1st switch only, this is not desired.

Change-Id: I27ef75a95889c37224aa7da6b0fbf8e2ad57ba65
Bug: https://github.com/mozilla-iot/gateway/issues/1148
Fixes #1148
Origin: https://github.com/tizenteam/gateway
Signed-off-by: Philippe Coval <p.coval@samsung.com>