### PR TITLE
ignore: Ignore emacs backup and tmp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Standard artifacts
+*~
 *.swp
 .DS_Store
 .nyc_output/
 .cache-loader/
+tmp/
 
 # Build artifacts
 /build


### PR DESCRIPTION
Folder tmp can be used as developer playground too
This change is mostly to test travis checker on current base

Change-Id: I7ef9231cc83af97e6b7ebd7a5a632379912a2d52
Signed-off-by: Philippe Coval <p.coval@samsung.com>