### PR TITLE
Disable redirect at changing local domain.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -186,6 +186,9 @@ const SettingsScreen = {
     addDomainLocalButton.addEventListener(
       'click', this.onLocalDomainClick.bind(this));
 
+    localDomainName.addEventListener(
+      'input', this.onLocalDomainNameChange.bind(this));
+
     // Comented out until full integration of Dynamic tunnel creation
     // with Service Discovery
     // const addDomainTunnelButton =
@@ -246,12 +249,23 @@ const SettingsScreen = {
     });
   },
 
+  onLocalDomainNameChange: function() {
+    const localDomainCheckbox =
+      document.getElementById('domain-settings-local-checkbox');
+    const localDomainButton =
+      document.getElementById('domain-settings-local-update');
+    localDomainButton.disabled = !localDomainCheckbox.checked;
+    localDomainButton.textContent = 'Update host name';
+  },
+
   // The button controller to update the local domain settings.
   // In menu -> Settings -> Domain
   onLocalDomainClick: function() {
     const localDomainName =
       document.getElementById('domain-settings-local-name');
     const error = document.getElementById('domain-settings-error');
+    const localDomainButton =
+      document.getElementById('domain-settings-local-update');
 
     fetch('/settings/domain', {
       method: 'PUT',
@@ -268,7 +282,8 @@ const SettingsScreen = {
       // is active then redirect
       if (domainJson.update && domainJson.localDomain.length > 0) {
         if (domainJson.mDNSstate) {
-          window.location.href = domainJson.localDomain;
+          localDomainButton.disabled = true;
+          localDomainButton.textContent = 'Update succeeded';
         }
       } else {
         error.classList.remove('hidden');


### PR DESCRIPTION
Fixes https://github.com/mozilla-iot/gateway/issues/1245.

This PR disable redirect rather than redirect http, because a) the user might change local domain outside of local network and b) enabling http access may have some issue. I think we should access gateway with https from outside of local network. However, restricting http access only from local network have to use modifiable headers like `Host` or `x-forwarded-for`. There are possibility to have security issue.

![image](https://user-images.githubusercontent.com/20137651/44347663-625b3780-a4d3-11e8-8dcd-94d39471d748.png)
