### PR TITLE
[tiny] enable icon on android and iOS

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,7 @@
     <title>Things Gateway</title>
     <link rel="manifest" href="/app.webmanifest">
     <link rel="icon" href="/optimized-images/icon.png" type="image/png" />
+    <link rel="apple-touch-icon-precomposed" href="/optimized-images/icon.png">
   </head>
   <body class="hidden">
     <!-- Assistant View -->

--- a/static/index.html
+++ b/static/index.html
@@ -10,7 +10,7 @@
     <title>Things Gateway</title>
     <link rel="manifest" href="/app.webmanifest">
     <link rel="icon" href="/optimized-images/icon.png" type="image/png" />
-    <link rel="apple-touch-icon-precomposed" href="/optimized-images/icon.png">
+    <link rel="apple-touch-icon-precomposed" href="/optimized-images/icon.png" type="image/png">
   </head>
   <body class="hidden">
     <!-- Assistant View -->


### PR DESCRIPTION
When pinning the things gateway to your mobile start screen this will make both phone OS to use the icon. 