### PR TITLE
Fix Settings scrolling

### DIFF
--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -157,7 +157,8 @@
   width: 100%;
   height: 100%;
   transition: transform 0.25s ease;
-  padding: 0 1.5rem;
+  padding: 0;
+  padding-bottom: 9.6rem;
   box-sizing: border-box;
   overflow-y: scroll;
 }
@@ -210,13 +211,13 @@
 #update-settings ul,
 #authorization-settings ul,
 #developer-settings ul {
-  position: relative;
+  position: absolute;
   top: 50%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
   box-sizing: border-box;
   width: 100%;
   max-width: 60rem;
-  margin: 0 auto;
   padding: 2rem;
   max-height: 100%;
 }

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -6,8 +6,7 @@
   background-color: #5d9bc7;
   height: 100%;
   box-sizing: border-box;
-  overflow-x: hidden;
-  overflow-y: scroll;
+  overflow: hidden;
 }
 
 #settings-view.dark {
@@ -15,11 +14,11 @@
   z-index: 50;
 }
 
-#section-title.hidden {
+.section-title.hidden {
   display: none;
 }
 
-#section-title {
+.section-title {
   width: 100%;
   text-align: center;
   height: 9.6rem;
@@ -29,7 +28,7 @@
   z-index: 10;
 }
 
-#section-title-container {
+.section-title-container {
   white-space: nowrap;
   color: #fff;
   text-overflow: ellipsis;
@@ -37,26 +36,26 @@
   line-height: 9.6rem;
 }
 
-#section-title-icon {
+.section-title-icon {
   height: 4rem;
   position: relative;
   top: 1.3rem;
   padding-right: 0.5rem;
 }
 
-#section-title-name {
+.section-title-name {
   font-size: 1.6rem;
 }
 
-#section-title-back-flex,
-#section-title-speech-flex {
+.section-title-back-flex,
+.section-title-speech-flex {
   flex: 1;
   min-width: 9.6rem;
   flex-shrink: 0;
   height: 9.6rem;
 }
 
-#section-title-speech-flex {
+.section-title-speech-flex {
   flex: 1;
   min-width: 0;
 }
@@ -150,7 +149,7 @@
   background-image: url('../optimized-images/developer-icon.svg');
 }
 
-.settings-section, .settings-subsection {
+.settings-section {
   position: absolute;
   top: 50%;
   transform: translate(0%, -50%);
@@ -158,8 +157,13 @@
   width: 100%;
   height: 100%;
   transition: transform 0.25s ease;
-  padding: 7.6rem 1.5rem;
+  padding: 0 1.5rem;
   box-sizing: border-box;
+  overflow-y: scroll;
+}
+
+.settings-subsection {
+  display: block;
 }
 
 .settings-section.hidden {
@@ -487,6 +491,7 @@
 
 #add-user-button,
 #discover-addons-button {
+  position: fixed;
   bottom: 2rem;
   right: 2rem;
   background-image: url('../optimized-images/add.svg');

--- a/static/index.html
+++ b/static/index.html
@@ -63,15 +63,6 @@
 
     <!-- Settings View -->
     <section data-view="settings" id="settings-view" class="hidden">
-      <div id="section-title" class="hidden">
-        <div id="section-title-back-flex"></div>
-        <div id="section-title-container">
-          <img id="section-title-icon" alt="Section Title" src="#" />
-          <span id="section-title-name"></span>
-        </div>
-        <div id="section-title-speech-flex"></div>
-      </div>
-
       <nav id="settings-menu" class="hidden settings-section">
         <ul>
           <li class="settings-item"><a id="domain-settings-link" href="/settings/domain">Domain</a></li>
@@ -132,7 +123,6 @@
         <section id="user-settings-main" class="hidden settings-subsection">
           <ul id="users-list">
           </ul>
-          <button id="add-user-button" class="icon-button"></button>
         </section>
         <section id="user-settings-edit" class="hidden settings-subsection">
           <form id="edit-user-form" class="user-form">
@@ -177,7 +167,6 @@
         <section id="addon-main-settings" class="hidden settings-subsection">
           <ul id="installed-addons-list">
           </ul>
-          <button id="discover-addons-button" class="icon-button"></button>
         </section>
         <section id="addon-config-settings" class="hidden settings-subsection">
         </section>
@@ -236,6 +225,8 @@
         </ul>
       </section>
       <a href="/settings" id="settings-back-button" class="hidden back-button icon-button"></a>
+      <button id="discover-addons-button" class="icon-button hidden"></button>
+      <button id="add-user-button" class="icon-button hidden"></button>
     </section>
 
     <!-- Rules View -->

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -29,15 +29,13 @@ const SettingsScreen = {
    */
   init: function() {
     this.view = document.getElementById('settings-view');
-    this.titleElement = document.getElementById('section-title');
-    this.titleName = document.getElementById('section-title-name');
-    this.titleIcon = document.getElementById('section-title-icon');
     this.menu = document.getElementById('settings-menu');
     this.domainSettings = document.getElementById('domain-settings');
     this.userSettings = document.getElementById('user-settings');
     this.userSettingsMain = document.getElementById('user-settings-main');
     this.userSettingsEdit = document.getElementById('user-settings-edit');
     this.userSettingsAdd = document.getElementById('user-settings-add');
+    this.addUserButton = document.getElementById('add-user-button');
     this.adapterSettings = document.getElementById('adapter-settings');
     this.addonSettings = document.getElementById('addon-settings');
     this.addonMainSettings = document.getElementById('addon-main-settings');
@@ -45,6 +43,8 @@ const SettingsScreen = {
     this.addonDiscoverySettings =
       document.getElementById('addon-discovery-settings');
     this.addonConfigSettings = document.getElementById('addon-config-settings');
+    this.discoverAddonsButton =
+      document.getElementById('discover-addons-button');
     this.experimentSettings = document.getElementById('experiment-settings');
     this.updateSettings = document.getElementById('update-settings');
     this.authorizationSettings =
@@ -55,14 +55,70 @@ const SettingsScreen = {
     this.availableAddons = new Map();
     this.installedAddons = new Map();
     this.fetchAddonDeferred = null;
+
+    this.insertTitleElement(this.menu, 'Settings',
+                            '/optimized-images/settings-icon.png');
+    this.insertTitleElement(this.domainSettings, 'Domain',
+                            '/optimized-images/domain-icon.png');
+    this.insertTitleElement(this.userSettingsMain, 'Users',
+                            '/optimized-images/users-icon.png');
+    this.insertTitleElement(this.userSettingsEdit, 'Edit User',
+                            '/optimized-images/user.svg');
+    this.insertTitleElement(this.userSettingsAdd, 'Add User',
+                            '/optimized-images/user.svg');
+    this.insertTitleElement(this.adapterSettings, 'Adapters',
+                            '/optimized-image/adapters-icon.png');
+    this.insertTitleElement(this.addonMainSettings, 'Add-ons',
+                            '/optimized-images/add-on.svg');
+    const addonConfigTitle =
+      this.insertTitleElement(this.addonConfigSettings,
+                              'Configure Add-on',
+                              '/optimized-images/add-on.svg');
+    this.addonConfigTitleName =
+      addonConfigTitle.querySelector('.section-title-name');
+
+    this.insertTitleElement(this.addonDiscoverySettings,
+                            'Discover New Add-ons',
+                            '/optimized-images/add-on.svg');
+    this.insertTitleElement(this.experimentSettings, 'Experiments',
+                            '/optimized-images/experiments-icon.png');
+    this.insertTitleElement(this.updateSettings, 'Updates',
+                            '/optimized-images/update-icon.svg');
+    this.insertTitleElement(this.authorizationSettings, 'Authorizations',
+                            '/optimized-images/authorization.svg');
+    this.insertTitleElement(this.developerSettings, 'Developer',
+                            '/optimized-images/developer-icon.svg');
+
+    this.discoverAddonsButton.addEventListener('click', () => {
+      page('/settings/addons/discovered');
+    });
+    this.addUserButton.addEventListener('click', () => {
+      page('/settings/users/add');
+    });
+  },
+
+  insertTitleElement: function(section, name, icon) {
+    const elt = document.createElement('div');
+    elt.classList.add('section-title');
+    elt.innerHTML = `
+      <div class="section-title-back-flex"></div>
+      <div class="section-title-container">
+        <img class="section-title-icon" alt="Section Title" src="${icon}" />
+        <span class="section-title-name">${name}</span>
+      </div>
+      <div class="section-title-speech-flex"></div>
+    `;
+    section.insertBefore(elt, section.firstChild);
+    return elt;
   },
 
   show: function(section, subsection, id) {
     document.getElementById('speech-wrapper').classList.remove('assistant');
 
     this.backButton.href = '/settings';
-    this.titleElement.classList.remove('hidden');
     this.view.classList.remove('dark');
+    this.discoverAddonsButton.classList.add('hidden');
+    this.addUserButton.classList.add('hidden');
 
     if (section) {
       this.showSection(section, subsection, id);
@@ -73,8 +129,6 @@ const SettingsScreen = {
 
   showMenu: function() {
     App.showMenuButton();
-    this.titleName.innerText = 'Settings';
-    this.titleIcon.src = '/optimized-images/settings-icon.png';
     this.hideBackButton();
     this.menu.classList.remove('hidden');
     this.domainSettings.classList.add('hidden');
@@ -91,6 +145,8 @@ const SettingsScreen = {
     this.updateSettings.classList.add('hidden');
     this.authorizationSettings.classList.add('hidden');
     this.developerSettings.classList.add('hidden');
+    this.discoverAddonsButton.classList.add('hidden');
+    this.addUserButton.classList.add('hidden');
   },
 
   hideMenu: function() {
@@ -170,8 +226,6 @@ const SettingsScreen = {
 
   showDomainSettings: function() {
     this.domainSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Domain';
-    this.titleIcon.src = '/optimized-images/domain-icon.png';
     const opts = {
       headers: API.headers(),
     };
@@ -342,14 +396,7 @@ const SettingsScreen = {
     this.userSettingsEdit.classList.add('hidden');
     this.userSettingsAdd.classList.add('hidden');
     this.userSettingsMain.classList.remove('hidden');
-    this.titleName.innerText = 'Users';
-    this.titleIcon.src = '/optimized-images/users-icon.png';
-
-    const addUserButton =
-      document.getElementById('add-user-button');
-    addUserButton.addEventListener('click', () => {
-      page('/settings/users/add');
-    });
+    this.addUserButton.classList.remove('hidden');
 
     API.getAllUserInfo().then((users) => {
       const usersList = document.getElementById('users-list');
@@ -367,8 +414,6 @@ const SettingsScreen = {
     this.userSettingsMain.classList.add('hidden');
     this.userSettingsAdd.classList.add('hidden');
     this.userSettingsEdit.classList.remove('hidden');
-    this.titleName.innerText = 'Edit User';
-    this.titleIcon.src = '/optimized-images/user.svg';
     this.view.classList.add('dark');
 
     API.getUser(id).then((user) => {
@@ -430,8 +475,6 @@ const SettingsScreen = {
     this.userSettingsMain.classList.add('hidden');
     this.userSettingsEdit.classList.add('hidden');
     this.userSettingsAdd.classList.remove('hidden');
-    this.titleName.innerText = 'Add User';
-    this.titleIcon.src = '/optimized-images/user.svg';
     this.view.classList.add('dark');
 
     const form = document.getElementById('add-user-form');
@@ -480,8 +523,6 @@ const SettingsScreen = {
 
   showAdapterSettings: function() {
     this.adapterSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Adapters';
-    this.titleIcon.src = '/optimized-images/adapters-icon.png';
 
     const opts = {
       headers: API.headers(),
@@ -606,14 +647,7 @@ const SettingsScreen = {
     this.addonDiscoverySettings.classList.add('hidden');
     this.addonConfigSettings.classList.add('hidden');
     this.addonMainSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Add-ons';
-    this.titleIcon.src = '/optimized-images/add-on.svg';
-
-    const discoverAddonsButton =
-      document.getElementById('discover-addons-button');
-    discoverAddonsButton.addEventListener('click', () => {
-      page('/settings/addons/discovered');
-    });
+    this.discoverAddonsButton.classList.remove('hidden');
 
     this.getAddonList().then(() => {
       const addonList = document.getElementById('installed-addons-list');
@@ -644,12 +678,15 @@ const SettingsScreen = {
     this.addonMainSettings.classList.add('hidden');
     this.addonConfigSettings.classList.remove('hidden');
     this.addonDiscoverySettings.classList.add('hidden');
-    this.titleName.innerText = `Configure ${id}`;
-    this.titleIcon.src = '/optimized-images/add-on.svg';
+    this.addonConfigTitleName.textContent = `Configure ${id}`;
     this.view.classList.add('dark');
 
     this.getAddonList().then(() => {
-      this.addonConfigSettings.innerHTML = '';
+      const existingForm =
+        this.addonConfigSettings.querySelector('.json-schema-form');
+      if (existingForm) {
+        existingForm.parentNode.removeChild(existingForm);
+      }
       const addon = this.installedAddons.get(id);
       new AddonConfig(id, addon);
     });
@@ -661,8 +698,6 @@ const SettingsScreen = {
     this.addonMainSettings.classList.add('hidden');
     this.addonConfigSettings.classList.add('hidden');
     this.addonDiscoverySettings.classList.remove('hidden');
-    this.titleName.innerText = 'Discover New Add-ons';
-    this.titleIcon.src = '/optimized-images/add-on.svg';
     this.view.classList.add('dark');
 
     this.getAddonList().then(() => {
@@ -704,8 +739,6 @@ const SettingsScreen = {
 
   showExperimentSettings: function() {
     this.experimentSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Experiments';
-    this.titleIcon.src = '/optimized-images/experiments-icon.png';
     this.showExperimentCheckbox('assistant', 'assistant-experiment-checkbox');
   },
 
@@ -743,8 +776,6 @@ const SettingsScreen = {
 
   showUpdateSettings: function() {
     this.updateSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Updates';
-    this.titleIcon.src = '/optimized-images/update-icon.svg';
     const updateNow = document.getElementById('update-now');
 
     updateNow.addEventListener('click', this.onUpdateClick);
@@ -827,8 +858,6 @@ const SettingsScreen = {
 
   showAuthorizationSettings: function() {
     this.authorizationSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Authorizations';
-    this.titleIcon.src = '/optimized-images/authorization.svg';
 
     fetch('/authorizations', {
       headers: API.headers(),
@@ -903,8 +932,6 @@ const SettingsScreen = {
 
   showDeveloperSettings: function() {
     this.developerSettings.classList.remove('hidden');
-    this.titleName.innerText = 'Developer';
-    this.titleIcon.src = '/optimized-images/developer-icon.svg';
 
     document.getElementById('view-logs').href = `/logs?jwt=${API.jwt}`;
     const sshCheckbox = document.getElementById('enable-ssh-checkbox');

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -67,7 +67,7 @@ const SettingsScreen = {
     this.insertTitleElement(this.userSettingsAdd, 'Add User',
                             '/optimized-images/user.svg');
     this.insertTitleElement(this.adapterSettings, 'Adapters',
-                            '/optimized-image/adapters-icon.png');
+                            '/optimized-images/adapters-icon.png');
     this.insertTitleElement(this.addonMainSettings, 'Add-ons',
                             '/optimized-images/add-on.svg');
     const addonConfigTitle =
@@ -103,7 +103,7 @@ const SettingsScreen = {
     elt.innerHTML = `
       <div class="section-title-back-flex"></div>
       <div class="section-title-container">
-        <img class="section-title-icon" alt="Section Title" src="${icon}" />
+        <img class="section-title-icon" alt="${name} Icon" src="${icon}" />
         <span class="section-title-name">${name}</span>
       </div>
       <div class="section-title-speech-flex"></div>


### PR DESCRIPTION
Moves settings titles from a shared element to a
section-by-section element, fixing setting section titles while
maintaining scroll-with-content behavior.

Fix #1290