### PR TITLE
Fix overlapping setting-title and UL elements.

### DIFF
--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -219,6 +219,7 @@
   width: 100%;
   max-width: 60rem;
   padding: 2rem;
+  padding-top: 9.6rem;
   max-height: 100%;
 }
 

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -218,8 +218,7 @@
   box-sizing: border-box;
   width: 100%;
   max-width: 60rem;
-  padding: 2rem;
-  padding-top: 9.6rem;
+  padding: 9.6rem 2rem;
   max-height: 100%;
 }
 


### PR DESCRIPTION
After https://github.com/mozilla-iot/gateway/pull/1291, some setting page elements are overlapped.
![image](https://user-images.githubusercontent.com/20137651/44596667-090f4300-a808-11e8-87ef-bdd1965a1e52.png)
