### PR TITLE
Tweaks for 0.5.1

### DIFF
--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -12,6 +12,8 @@
 #   - /build/Open-ZWave/open-zwave  - git repository containing the desired version of OpenZWave
 #   - /build/gateway                - git repository containing the gateway software
 
+set -e
+
 NVM_VERSION="v0.33.8"
 NODE_VERSION="--lts=carbon"
 

--- a/image/image-to-aws.sh
+++ b/image/image-to-aws.sh
@@ -44,6 +44,10 @@ image_to_aws() {
   echo "Copying image files to '${AWS_DIR}'"
   aws s3 cp --acl=public-read "${IMG_FILENAME}.zip" "${AWS_DIR}"
   aws s3 cp --acl=public-read "${IMG_FILENAME}.zip.sha256sum" "${AWS_DIR}"
+
+  echo "AWS URLs"
+  echo "https://s3-us-west-1.amazonaws.com/mozillagatewayimages/${AWS_DIR}/${IMG_FILENAME}.zip"
+  echo "https://s3-us-west-1.amazonaws.com/mozillagatewayimages/${AWS_DIR}/${IMG_FILENAME}.zip.sha256sum"
 }
 
 ###########################################################################

--- a/image/make-prep.sh
+++ b/image/make-prep.sh
@@ -432,7 +432,7 @@ main() {
 
   # Adding a sleep here helps ensure that the mounted directories are
   # not actually still in use.
-  sleep 1
+  sleep 3
 
   cleanup
 

--- a/image/prepare-base-root.sh
+++ b/image/prepare-base-root.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -e
 
-# Allow node and python3 to use the Bluetooth adapter
-setcap cap_net_raw+eip $(eval readlink -f `which node`)
-setcap cap_net_raw+eip $(eval readlink -f `which python3`)
-
 # disable hostapd and dnsmasq auto start
 systemctl disable hostapd.service
 systemctl disable dnsmasq.service


### PR DESCRIPTION
- Mostly minor
- removed setcap from prepare-base-root since it's already done
  in prepare-base and node isn't installed for root anyways
  which was causing the `which node` portion to fail.