### PR TITLE
Fix certificate renewal.

### DIFF
--- a/tools/renew-certificates.sh
+++ b/tools/renew-certificates.sh
@@ -9,6 +9,9 @@ for file in $(find "${MOZIOT_HOME}/etc/renewal" -type f -name '*.conf'); do
 
     # Disable OCSP stapling
     sed -i -e 's/^must_staple.*/must_staple = False/' "${file}"
+
+    # Fix webroot path
+    sed -i -e 's_gateway/static_gateway/build/static_' "${file}"
 done
 
 for file in $(find "${MOZIOT_HOME}/etc/accounts" -type f -name regr.json); do


### PR DESCRIPTION
At some point, the webroot path was changed. Older gateways that
started with the old webroot path became broken at that point.

This commit adds a step to the renewal process to fix up any old
config files, such that renewal works again.