### PR TITLE
Stop reconnect websocket when things removed.

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -2,6 +2,7 @@ exports.EVENT_OCCURRED = 'eventOccurred';
 exports.PROPERTY_STATUS = 'propertyStatus';
 exports.REFRESH_THINGS = 'refreshThings';
 exports.DELETE_THINGS = 'deleteThings';
+exports.DELETE_THING = 'deleteThing';
 
 exports.ThingFormat = {
   INTERACTIVE: 0,

--- a/static/js/models/gateway-model.js
+++ b/static/js/models/gateway-model.js
@@ -49,6 +49,10 @@ class GatewayModel extends Model {
   setThing(thingId, description) {
     if (!this.thingModels.has(thingId)) {
       const thingModel = new ThingModel(description);
+      thingModel.subscribe(
+        Constants.DELETE_THING,
+        this.handleRemove.bind(this)
+      );
       this.thingModels.set(thingId, thingModel);
     }
     this.things.set(thingId, description);
@@ -87,9 +91,7 @@ class GatewayModel extends Model {
         throw new Error(`Thing id:${thingId} already removed`);
       }
       const thingModel = this.thingModels.get(thingId);
-      return thingModel.removeThing().then(() => {
-        this.handleRemove(thingId);
-      });
+      return thingModel.removeThing();
     });
   }
 

--- a/static/js/things.js
+++ b/static/js/things.js
@@ -253,11 +253,7 @@ const ThingsScreen = {
       this.refreshThing,
       true
     );
-    App.gatewayModel.subscribe(
-      Constants.DELETE_THINGS,
-      this.refreshThing,
-      true
-    );
+    App.gatewayModel.subscribe(Constants.DELETE_THINGS, this.refreshThing);
   },
 
   /**

--- a/static/js/things.js
+++ b/static/js/things.js
@@ -192,6 +192,7 @@ const ThingsScreen = {
    */
   showThings: function() {
     App.gatewayModel.unsubscribe(Constants.REFRESH_THINGS, this.refreshThing);
+    App.gatewayModel.unsubscribe(Constants.DELETE_THINGS, this.refreshThing);
     App.gatewayModel.subscribe(Constants.DELETE_THINGS, this.refreshThings);
     App.gatewayModel.subscribe(
       Constants.REFRESH_THINGS,
@@ -206,6 +207,7 @@ const ThingsScreen = {
    */
   showThing: function(thingId) {
     App.gatewayModel.unsubscribe(Constants.REFRESH_THINGS, this.refreshThing);
+    App.gatewayModel.unsubscribe(Constants.DELETE_THINGS, this.refreshThing);
     App.gatewayModel.unsubscribe(Constants.REFRESH_THINGS, this.refreshThings);
     App.gatewayModel.unsubscribe(Constants.DELETE_THINGS, this.refreshThings);
 
@@ -248,6 +250,11 @@ const ThingsScreen = {
 
     App.gatewayModel.subscribe(
       Constants.REFRESH_THINGS,
+      this.refreshThing,
+      true
+    );
+    App.gatewayModel.subscribe(
+      Constants.DELETE_THINGS,
       this.refreshThing,
       true
     );


### PR DESCRIPTION
Fixes #1348 

pattern1.
1. open UI.
2. add many things.
3. reconnect UI.
4. remove thing before websocket open.
    Connecting many websockets from UI take as much time as we remove a thing from UI because that is not pararell.

pattern2.
1. open UI
2. add a thing.
3. delete thing with webthings API
    ```
    curl -XDELETE -H "Authorization: Bearer hogehoge"   -H "Accept: application/json"    https://yourdomain.mozilla-iot.org/things/addedthing-id
    ```