### PR TITLE
Get rid of warning from dynamicRequire().

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -32,14 +32,17 @@ const pkg = require('../package.json');
 
 let PluginClient, PluginServer;
 
-// Use webpack provided require for dynamic includes from the bundle  .
-const dynamicRequire = (() => {
-  if (typeof __non_webpack_require__ !== 'undefined') {
-    // eslint-disable-next-line no-undef
-    return __non_webpack_require__;
-  }
-  return require;
-})();
+let dynamicRequire;
+if (config.get('ipc.protocol') === 'inproc') {
+  // Use webpack provided require for dynamic includes from the bundle  .
+  dynamicRequire = (() => {
+    if (typeof __non_webpack_require__ !== 'undefined') {
+      // eslint-disable-next-line no-undef
+      return __non_webpack_require__;
+    }
+    return require;
+  })();
+}
 
 /**
  * @class AddonManager


### PR DESCRIPTION
This seems to confuse a lot of people and make them think that
something is wrong, when everything is fine.