### PR TITLE
Propogate property min/max

### DIFF
--- a/src/plugin/property-proxy.js
+++ b/src/plugin/property-proxy.js
@@ -46,6 +46,12 @@ class PropertyProxy extends Property {
   doPropertyChanged(propertyDict) {
     this.propertyDict = Object.assign({}, propertyDict);
     this.setCachedValue(propertyDict.value);
+    if (propertyDict.hasOwnProperty('minimum')) {
+      this.minimum = propertyDict.minimum;
+    }
+    if (propertyDict.hasOwnProperty('maximum')) {
+      this.maximum = propertyDict.maximum;
+    }
     while (this.propertyChangedPromises.length > 0) {
       const deferredChange = this.propertyChangedPromises.pop();
       deferredChange.resolve(propertyDict.value);


### PR DESCRIPTION
This updates the gateway side min/max with new values if the
adapter side changes. This was needed to support color temperature
from bulbs which present the min/max as attributes which need to
be read.