### PR TITLE
build: install defaults versions if not overloaded

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 
-NVM_VERSION="v0.33.8"
-NODE_VERSION="--lts=carbon"
-
+[ "$NVM_VERSION" != "" ] || NVM_VERSION="v0.33.8"
+[ "$NODE_VERSION" != "" ] || NODE_VERSION="--lts=carbon"
 [ "$USER" != "" ] || USER="pi"
 [ "$HOME" != "" ] || HOME="/home/${USER}"
 cd "${HOME}"


### PR DESCRIPTION
Achitecture armhf seems not support on this release,
so it can be overloaded from parent shell.

Change-Id: I878d048e08eac62de9bfdf45bcc92e24cb55af9e
Signed-off-by: Philippe Coval <p.coval@samsung.com>