### PR TITLE
build: Add Dockerfile to rebuild in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+*~
+Dockerfile
+
+#{ [[./.gitignore]]
+# Standard artifacts
+*.swp
+.DS_Store
+.nyc_output/
+.cache-loader/
+
+# Build artifacts
+/build
+node_modules/
+static/js/lib/stm_web.min.js
+
+# Run-time artifacts
+.node-persist/
+config/local.js
+static/uploads
+.post_upgrade_complete
+/browser-test-output
+#} [[./.gitignore]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+#{
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+#}
+# WARNING: this docker file is *ONLY* for developer convenience
+# WARNING: for production deployment please consider supported project:
+# WARNING: https://github.com/mozilla-iot/gateway-docker
+
+FROM debian:stable
+LABEL maintainer="p.coval@samsung.com"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL en_US.UTF-8
+ENV LANG ${LC_ALL}
+
+RUN echo "#log: Configuring locales" \
+  && set -x \
+  && apt-get update -y \
+  && apt-get install -y locales \
+  && echo "${LC_ALL} UTF-8" | tee /etc/locale.gen \
+  && locale-gen ${LC_ALL} \
+  && dpkg-reconfigure locales \
+  && sync
+
+ENV project mozilla-iot
+
+RUN echo "#log: ${project}: Setup system" \
+  && set -x \
+  && apt-get update -y \
+  && apt-get install -y \
+  sudo \
+  && apt-get clean \
+  && sync
+
+ADD . /root/mozilla-iot/gateway
+WORKDIR /root/mozilla-iot/gateway/..
+RUN echo "#log: ${project}: Preparing sources" \
+  && set -x \
+  && ./gateway/install.sh \
+  && sync
+
+EXPOSE 8080
+WORKDIR /root/mozilla-iot/gateway
+CMD [ "./run-app.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# WARNING: this docker file is *ONLY* for developer convenience
+# WARNING: for production deployment please consider supported project:
+# WARNING: https://github.com/mozilla-iot/gateway-docker
+
+version: "2"
+
+services:
+  web:
+    build: .
+    command: /root/mozilla-iot/gateway/run-app.sh
+    volumes:
+      - /root/mozilla-iot/gateway
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
This docker file is a conveinance tool for developers,
for production deployment please consider this project:

https://github.com/mozilla-iot/gateway-docker

Also run-app.sh can be used to start gw,
more changes to come later.

Usage:

    docker-compose up

Change-Id: Ia082fdcb1b945645ff5c058760dbefed8843eea8
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>