### PR TITLE
Temporary: Downgrade Firefox to 62 until webdriver behaves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - MOZIOT_HOME=/home/travis/.mozilla-iot/test
 
 addons:
-  firefox: latest
+  firefox: "62.0"
   apt:
     sources:
       - ubuntu-toolchain-r-test


### PR DESCRIPTION
Since I couldn't find a real reason for it to be broken