### PR TITLE
Add --production to gateway build script

### DIFF
--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -78,7 +78,7 @@ nvm use ${NODE_VERSION}
 npm install -g yarn
 
 # Build the node modules, cross compiling any native code.
-(cd ${GATEWAY}; yarn --ignore-scripts; npm rebuild --arch=${ARCH} --target_arch=arm; node_modules/.bin/webpack)
+(cd ${GATEWAY}; yarn --ignore-scripts --production; npm rebuild --arch=${ARCH} --target_arch=arm; node_modules/.bin/webpack)
 
 set -x
 

--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -77,8 +77,11 @@ nvm use ${NODE_VERSION}
 
 npm install -g yarn
 
-# Build the node modules, cross compiling any native code.
-(cd ${GATEWAY}; yarn --ignore-scripts --production; npm rebuild --arch=${ARCH} --target_arch=arm; node_modules/.bin/webpack)
+# Install development-specific node modules and prerun webpack
+(cd ${GATEWAY}; yarn; node_modules/.bin/webpack)
+# Clear out node_modules just in case then build only the modules we'll use in
+# the image, cross compiling any native code.
+(cd ${GATEWAY}; rm -r node_modules; yarn --ignore-scripts --production; npm rebuild --arch=${ARCH} --target_arch=arm)
 
 set -x
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "watch": "npm-run-all --parallel start watch:build",
     "watch:build": "webpack --watch",
     "debug-ide": "webpack && node --inspect=5858 build/gateway.js",
-    "debug": "webpack && node --inspect build/gateway.js"
+    "debug": "webpack && node --inspect build/gateway.js",
+    "run-only": "node build/gateway.js"
   },
   "repository": {
     "type": "git",

--- a/run-app.sh
+++ b/run-app.sh
@@ -4,6 +4,7 @@ set -x
 
 MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
 args=""
+start_task="start"
 
 is_docker_container() {
   if [ -f /.dockerenv ]; then
@@ -18,6 +19,7 @@ is_docker_container() {
 }
 if ! is_docker_container; then
   args="$args --check-wifi"
+  start_task="run-only"
   if [ ! -f .post_upgrade_complete ]; then
     ./tools/post-upgrade.sh
   fi
@@ -36,7 +38,7 @@ run_app() {
   echo "npm version"
   npm --version
   echo "Starting gateway ..."
-  npm start -- $args
+  npm run $start_task -- $args
 }
 
 mkdir -p "${MOZIOT_HOME}/log"

--- a/tools/generate-release.sh
+++ b/tools/generate-release.sh
@@ -16,6 +16,7 @@ git clone ./ gateway
 cd gateway
 git remote set-url origin "${_remote}"
 cp -r ../node_modules ./
+yarn
 ./node_modules/.bin/webpack
 rm -fr ./node_modules
 cd ..


### PR DESCRIPTION
Lets us actually take advantage of the benefits from splitting out dependencies and devDependencies. Reduces node_modules from 525M to 174M.

Will require a bunch of testing in 0.7 or 0.6.2