### PR TITLE
ci: use yarn for all CI commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,11 @@ before_script:
 script:
   - yarn
   - node ./node_modules/webpack/bin/webpack.js
-  - npm run lint
+  - yarn run lint
   - ./tools/make-self-signed-cert.sh
   - ./node_modules/.bin/jest --runInBand --coverage
-  - npm run yarn-check
-  - npm run dependencies-check
+  - yarn run yarn-check
+  - yarn run dependencies-check
 
 after_script:
   - ./node_modules/.bin/codecov


### PR DESCRIPTION
There are some parts with `npm`, we can change these to `yarn`.