### PR TITLE
Add new /media route.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,7 @@ exports.SETTINGS_PATH = '/settings';
 exports.COMMANDS_PATH = '/commands';
 exports.UPDATES_PATH = '/updates';
 exports.UPLOADS_PATH = '/uploads';
+exports.MEDIA_PATH = '/media';
 exports.DEBUG_PATH = '/debug';
 exports.RULES_PATH = '/rules';
 exports.OAUTH_PATH = '/oauth';

--- a/src/router.js
+++ b/src/router.js
@@ -87,9 +87,12 @@ const Router = {
     app.use(APP_PREFIX + Constants.OAUTH_PATH, nocache,
             require('./controllers/oauth_controller').default);
 
-    // Web app routes - send index.html and fall back to client side URL router
+    // Handle static media files before other static content. These must be
+    // authenticated.
     app.use(APP_PREFIX + Constants.MEDIA_PATH, nocache, auth,
             express.static(UserProfile.mediaDir));
+
+    // Web app routes - send index.html and fall back to client side URL router
     app.use(`${APP_PREFIX}/*`, require('./controllers/root_controller'));
 
     // Unauthenticated API routes

--- a/src/router.js
+++ b/src/router.js
@@ -44,7 +44,7 @@ const Router = {
 
     // First look for a static file
     const staticHandler = express.static(Constants.BUILD_STATIC_PATH);
-    app.use('/uploads', express.static(UserProfile.uploadsDir));
+    app.use(Constants.UPLOADS_PATH, express.static(UserProfile.uploadsDir));
     app.use((request, response, next) => {
       if (request.path === '/' && request.accepts('html')) {
         // We need this to hit RootController.
@@ -88,6 +88,8 @@ const Router = {
             require('./controllers/oauth_controller').default);
 
     // Web app routes - send index.html and fall back to client side URL router
+    app.use(APP_PREFIX + Constants.MEDIA_PATH, nocache, auth,
+            express.static(UserProfile.mediaDir));
     app.use(`${APP_PREFIX}/*`, require('./controllers/root_controller'));
 
     // Unauthenticated API routes

--- a/src/user-profile.js
+++ b/src/user-profile.js
@@ -27,6 +27,7 @@ const Profile = {
     this.configDir = path.join(this.baseDir, 'config');
     this.sslDir = path.join(this.baseDir, 'ssl');
     this.uploadsDir = path.join(this.baseDir, 'uploads');
+    this.mediaDir = path.join(this.baseDir, 'media');
     this.logDir = path.join(this.baseDir, 'log');
     this.gatewayDir = path.join(__dirname, '..');
 


### PR DESCRIPTION
Add-ons can store media here, such as images and videos, and use
an href to this path. The route is authenticated, so nothing is
open to the world.