### PR TITLE
Remove Eddystone beacon.

### DIFF
--- a/src/wifi-setup/app.js
+++ b/src/wifi-setup/app.js
@@ -137,11 +137,9 @@ function handleConnecting(request, response) {
     fs.closeSync(fs.openSync(wifiskipPath, 'w'));
     console.log('skip wifi setup. stop the ap');
     response.send(connectingTemplate({skip: 'true'}));
-    wifi.stopAP()
-      .then(() => wifi.broadcastBeacon())
-      .then(() => {
-        WiFiSetupApp.onConnection();
-      });
+    wifi.stopAP().then(() => {
+      WiFiSetupApp.onConnection();
+    });
     return;
   }
 
@@ -180,7 +178,6 @@ function handleConnecting(request, response) {
     })
     .then(() => wifi.defineNetwork(ssid, password))
     .then(() => wifi.waitForWiFi(20, 3000))
-    .then(() => wifi.broadcastBeacon())
     .then(() => {
       WiFiSetupApp.onConnection();
     })

--- a/src/wifi-setup/platforms/default.js
+++ b/src/wifi-setup/platforms/default.js
@@ -58,9 +58,4 @@ module.exports = {
 
   // Lists configured networks
   listNetworks: 'wpa_cli -iwlan0 list_networks',
-
-  // Broadcast an Eddystone beacon
-  broadcastBeacon:
-    // eslint-disable-next-line
-    'sudo hciconfig hci0 up && sudo hciconfig hci0 leadv 3 && sudo hcitool -i hci0 cmd',
 };


### PR DESCRIPTION
Eddystone beacons are no longer supported in Android or iOS, and
this support was finicky as it was.

Fixes #1570