### PR TITLE
Disable Node 11 testing by Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 8
   - 10
-  - 11
 
 cache:
   yarn: true


### PR DESCRIPTION
It fails for no reason frequently, and our add-ons don't even
support this version.