### PR TITLE
add optargs to show usage of LTS for NVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,31 +66,6 @@ nvm allows you to easily install different versions of node. To install nvm:
 $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 ```
 
-Reinitialize your terminal session.
-
-```
-$ . ~/.bashrc
-```
-
-Use nvm to install and use an LTS version of node and then set the
-default version. The **`.nvmrc`** file will be used by nvm to determine which version of node to install.
-
-```
-$ nvm install
-$ nvm use
-$ nvm alias default $(node -v)
-```
-
-Verify that node and npm have been installed:
-```
-$ node --version
-v8.12.0
-$ npm --version
-6.4.1
-```
-
-Note: these versions might differ from the LTS version installed locally.
-
 ### Install node (if you didn't use nvm)
 
 (If you already installed node via nvm you can skip this step)
@@ -273,6 +248,31 @@ python3 -m pip install git+https://github.com/mozilla-iot/gateway-addon-python.g
 
     ```
     $ cd gateway
+    ```
+
+* Use nvm to install and use an LTS version of node and then set the default version. The **`.nvmrc`** file will be used by nvm to determine which version of node to install.
+
+    ```
+    $ nvm install
+    $ nvm use
+    $ nvm alias default $(node -v)
+    ```
+
+* Verify that node and npm have been installed:
+
+    ```
+    $ node --version
+    v8.12.0
+    $ npm --version
+    6.4.1
+    ```
+
+    Note: these versions might differ from the LTS version installed locally.
+
+* Reinitialize your terminal session.
+
+    ```
+    $ . ~/.bashrc
     ```
 
 * Install dependencies:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ $ brew install autoconf
 
 Under x86-64 or x86 Ubuntu/Debian Linux:
 ```
-$ sudo apt-get install libpng12-0
+$ sudo apt-get install libpng16-16
 ```
 
 Under ARM Ubuntu/Debian Linux:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ nvm allows you to easily install different versions of node. To install nvm:
 $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 ```
 
+Reinitialize your terminal session.
+
+```
+$ . ~/.bashrc
+```
+
 ### Install node (if you didn't use nvm)
 
 (If you already installed node via nvm you can skip this step)
@@ -250,7 +256,7 @@ python3 -m pip install git+https://github.com/mozilla-iot/gateway-addon-python.g
     $ cd gateway
     ```
 
-* Use nvm to install and use an LTS version of node and then set the default version. The **`.nvmrc`** file will be used by nvm to determine which version of node to install.
+* If you have chosen to install nvm above, install and use an LTS version of node and then set the default version. The **`.nvmrc`** file will be used by nvm to determine which version of node to install.
 
     ```
     $ nvm install
@@ -268,12 +274,6 @@ python3 -m pip install git+https://github.com/mozilla-iot/gateway-addon-python.g
     ```
 
     Note: these versions might differ from the LTS version installed locally.
-
-* Reinitialize your terminal session.
-
-    ```
-    $ . ~/.bashrc
-    ```
 
 * Install dependencies:
     * **NOTE**: `yarn` is preferred but `npm install` will also work. To temporarily use `yarn` run `npx yarn` or for a permanent installation follow the

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Use nvm to install and use an LTS version of node and then set the
 default version. The **`.nvmrc`** file will be used by nvm to determine which version of node to install.
 
 ```
-$ nvm install --lts
-$ nvm use --lts
+$ nvm install
+$ nvm use
 $ nvm alias default $(node -v)
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Use nvm to install and use an LTS version of node and then set the
 default version. The **`.nvmrc`** file will be used by nvm to determine which version of node to install.
 
 ```
-$ nvm install
-$ nvm use
+$ nvm install --lts
+$ nvm use --lts
 $ nvm alias default $(node -v)
 ```
 


### PR DESCRIPTION
Not being familiar with NVM, didn't know it had to be called. As LTS is recommended, add it to the docs so copy and paste just works