### PR TITLE
Fix capability selector in edit menu.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -112,7 +112,8 @@ const ContextMenu = {
           const option = document.createElement('option');
           option.value = capability;
 
-          if (e.detail.selectedCapability === capability) {
+          if (e.detail.selectedCapability === capability ||
+              (capability === 'Custom' && !e.detail.selectedCapability)) {
             option.selected = true;
           }
 


### PR DESCRIPTION
If a thing's capabilities changed such that the old selected
capability was no longer valid, the selector would not show the
correct capability as selected by default.