### PR TITLE
Fix read-only labels.

### DIFF
--- a/static/js/property-detail/brightness.js
+++ b/static/js/property-detail/brightness.js
@@ -63,9 +63,6 @@ class BrightnessDetail {
       return;
     }
 
-    if (brightness == this.brightness.value) {
-      return;
-    }
     this.brightness.value = brightness;
   }
 

--- a/static/js/property-detail/color-temperature.js
+++ b/static/js/property-detail/color-temperature.js
@@ -52,10 +52,6 @@ class ColorTemperatureDetail {
       return;
     }
 
-    if (temperature == this.temperature.value) {
-      return;
-    }
-
     this.temperature.value = temperature;
   }
 

--- a/static/js/property-detail/color.js
+++ b/static/js/property-detail/color.js
@@ -35,9 +35,10 @@ class ColorDetail {
   }
 
   update(color) {
-    if (color == this.color.value) {
+    if (!this.color) {
       return;
     }
+
     this.color.value = color;
   }
 

--- a/static/js/property-detail/enum.js
+++ b/static/js/property-detail/enum.js
@@ -70,7 +70,7 @@ class EnumDetail {
   }
 
   update(value) {
-    if (!this.select || value == this.select.value) {
+    if (!this.select) {
       return;
     }
 

--- a/static/js/property-detail/level.js
+++ b/static/js/property-detail/level.js
@@ -66,9 +66,6 @@ class LevelDetail {
       return;
     }
 
-    if (level == this.level.value) {
-      return;
-    }
     this.level.value = level;
   }
 

--- a/static/js/property-detail/number.js
+++ b/static/js/property-detail/number.js
@@ -83,7 +83,7 @@ class NumberDetail {
    * Update the detail view with the new property value.
    */
   update(number) {
-    if (!this.input || number == this.input.value) {
+    if (!this.input) {
       return;
     }
 

--- a/static/js/property-detail/string.js
+++ b/static/js/property-detail/string.js
@@ -52,7 +52,7 @@ class StringDetail {
    * Update the detail view with the new property value.
    */
   update(string) {
-    if (!this.input || string == this.input.value) {
+    if (!this.input) {
       return;
     }
 


### PR DESCRIPTION
Found an issue where labels were not being displayed properly. To
reproduce, do the following:
* Change the level property in virtual-things-adapter to have a
  value of 50.
* Add the Virtual Multi-Level Sensor.
* Observe that level property bar is empty.