### PR TITLE
Fix browser tests on Firefox 63+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - NODE_TLS_REJECT_UNAUTHORIZED=0
 
 addons:
-  firefox: "62.0"
+  firefox: latest
   apt:
     sources:
       - ubuntu-toolchain-r-test

--- a/src/test/browser/page-object/things-page.js
+++ b/src/test/browser/page-object/things-page.js
@@ -9,10 +9,10 @@ class ThingSection extends Section {
     this.defineElement(
       'clickable',
       [
-        'webthing-light-capability > div',
-        'webthing-multi-level-switch-capability > div',
-        'webthing-on-off-switch-capability > div',
-        'webthing-smart-plug-capability > div',
+        'webthing-light-capability',
+        'webthing-multi-level-switch-capability',
+        'webthing-on-off-switch-capability',
+        'webthing-smart-plug-capability',
       ].join(',')
     );
     this.defineElement(

--- a/src/test/browser/things-view/thing-test.js
+++ b/src/test/browser/things-view/thing-test.js
@@ -14,7 +14,7 @@ const Utils = require(`${STATIC_JS_PATH}/utils`);
 
 
 describe('Thing', () => {
-  it('should render an unknown-thing and be able to change properties',
+  it('should render an unknown thing and be able to change properties',
      async () => {
        const browser = getBrowser();
        const desc = {


### PR DESCRIPTION
FF 63 enabled native web components, rather than using the polyfill.
WebDriver/Selenium don't currently support the shadow DOM properly,
so we have to work around that.

Fixes #1445