### PR TITLE
Fix bug with rearranging icons.

### DIFF
--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -604,6 +604,8 @@ class Thing {
         if (!response.ok) {
           console.error(`Failed to arrange thing ${id}`);
         }
+
+        App.gatewayModel.refreshThings();
       }).catch((e) => {
         console.error(`Error trying to arrange thing ${id}: ${e}`);
       });


### PR DESCRIPTION
STR:
1. Move an icon.
2. Open thing detail view.
3. Click back button.

Expected:
Things remain in positions they were just moved into.

Actual:
Things revert to previous position until UI is refreshed.