### PR TITLE
Guard against sending empty arrays when logs don't exist

### DIFF
--- a/src/controllers/logs_controller.js
+++ b/src/controllers/logs_controller.js
@@ -165,6 +165,9 @@ LogsController.ws('/', (websocket) => {
   }, 30 * 1000);
 
   function streamMetric(metrics) {
+    if (!metrics || metrics.length === 0) {
+      return;
+    }
     try {
       websocket.send(JSON.stringify(metrics), (_err) => {});
     } catch (_e) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -138,8 +138,9 @@ const App = {
 
     const onMessage = (msg) => {
       const message = JSON.parse(msg.data);
-
-      this.showMessage(message.message, 5000, message.url);
+      if (message && message.message) {
+        this.showMessage(message.message, 5000, message.url);
+      }
     };
 
     const cleanup = () => {


### PR DESCRIPTION
Related to #1793, most likely fixes it for normal use cases. If someone is using the 0.7 UI to look at the 0.8 backend this prevents 3 "undefined" messages from showing up. The "undefined" messages shouldn't be stuck on screen though so it's likely that the second part of #1793 is the proposed 0.8 -> 0.7 -> 0.8 transition 