### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Web of Things gateway",
   "main": "src/app.js",
   "scripts": {


### PR DESCRIPTION
I tested the OTA from 0.7.0 to 0.8.1 and it fixed the captive portal issue. I'll be testing 0.8.0 -> 0.8.1 right after this.

@mrstegeman Any objections to rolling out an OTA tonight?