### PR TITLE
Stepping a non-interpolated value to the right should use the previous value, not the next

### DIFF
--- a/static/js/logs/log.js
+++ b/static/js/logs/log.js
@@ -524,12 +524,13 @@ class Log {
         this.property.type === 'integer') {
       // Add a point so that the value steps down instead of gradually
       // decreasing
+      const lastPoint = points[points.length - 1];
       points.push({
-        x: points[points.length - 1].x,
-        y: rightPoint.y,
+        x: lastPoint.x,
+        y: lastPoint.y,
       }, {
         x: this.xStart + this.graphWidth,
-        y: rightPoint.y,
+        y: lastPoint.y,
       });
     } else if (points.length > 0) {
       const borderPoint = this.interpolate(points[points.length - 1],


### PR DESCRIPTION
old:
```
   _____
__|    
```

new (actual data, would be shown by old if scrolled properly):
```
   ___
__|   |__
```