### PR TITLE
WIP: Switch to Jasmine test runner from Jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6454,6 +6454,22 @@
         "handlebars": "^4.1.0"
       }
     },
+    "jasmine": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.4.0.tgz",
+      "integrity": "sha512-sR9b4n+fnBFDEd7VS2el2DeHgKcPiMVn44rtKFumq9q7P/t8WrxsVIZPob4UDdgcDNCwyDqwxCt4k9TDRmjPoQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "jasmine-core": "~3.4.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
+      "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
+      "dev": true
+    },
     "jest": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "highlightjs": "^9.12.0",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
+    "jasmine": "^3.4.0",
     "jest": "^24.7.1",
     "jsdom": "^14.0.0",
     "jsonfile": "^5.0.0",

--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -43,4 +43,4 @@ python3 "${MOZIOT_TEST_HOME}/intent-parser/intent-parser-server.py" &
 INTENT_SERVER_PID=$!
 
 # Run the tests
-NODE_TLS_REJECT_UNAUTHORIZED=0 "${SCRIPTDIR}/../../node_modules/.bin/jest" --runInBand --detectOpenHandles "$@"
+NODE_TLS_REJECT_UNAUTHORIZED=0 "${SCRIPTDIR}/../../node_modules/.bin/jasmine" "$@"


### PR DESCRIPTION
We disable 90% of what jest does so we should just use a normal test
runner that doesn't randomly fail to run tests.

This still needs to replace `jest --coverage` but is at least green on travis