### PR TITLE
Handle missing display_name and author with as much paranoia as possible

### DIFF
--- a/static/js/views/installed-addon.js
+++ b/static/js/views/installed-addon.js
@@ -29,8 +29,10 @@ class InstalledAddon {
     this.description = metadata.description;
     if (typeof metadata.author === 'object') {
       this.author = metadata.author.name;
-    } else {
+    } else if (typeof metadata.author === 'string') {
       this.author = metadata.author.split('<')[0].trim();
+    } else {
+      this.author = 'Unknown';
     }
     this.homepage = metadata.homepage;
     this.license =

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -1520,7 +1520,11 @@ const SettingsScreen = {
       addonList.innerHTML = '';
 
       Array.from(this.installedAddons.entries())
-        .sort((a, b) => a[1].display_name.localeCompare(b[1].display_name))
+        .sort((a, b) => {
+          const aName = a[1].display_name || a[1].name || '';
+          const bName = b[1].display_name || b[1].name || '';
+          return aName.localeCompare(bName);
+        })
         .forEach((x) => {
           components.set(
             x[0],


### PR DESCRIPTION
Not necessarily useful day-to-day as the addon-list already enforces
their existence but is at least a good fallback when I
inevitably forget to include one in an addon.