### PR TITLE
Fix issue with reading some SHA256SUMS files.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -685,7 +685,11 @@ class AddonManager extends EventEmitter {
         const lines = data.trim().split(/\r?\n/);
         for (const line of lines) {
           const checksum = line.slice(0, 64);
-          const filename = line.slice(64).trimLeft();
+          let filename = line.slice(64).trimLeft();
+
+          if (filename.startsWith('*')) {
+            filename = filename.substring(1);
+          }
 
           if (Utils.hashFile(path.join(addonPath, filename)) !== checksum) {
             const err =


### PR DESCRIPTION
If the file contains binary mode indicators, we would fail to load
the package. For example:

6b74a1c25290119492178e96f1f3692cfbf976b776066f8f2e74280e5aa93c76 *package.json