### PR TITLE
Fixes an issue that run-app.sh fails in container

### DIFF
--- a/run-app.sh
+++ b/run-app.sh
@@ -28,7 +28,12 @@ run_app() {
   export NVM_DIR="$HOME/.nvm"
   [ ! -s "$NVM_DIR/nvm.sh" ] || \. "$NVM_DIR/nvm.sh"  # This loads nvm
 
-  sudo /sbin/ldconfig
+  if [! is_docker_container]; then
+    sudo /sbin/ldconfig
+  else
+    /sbin/ldconfig
+  fi
+
 
   echo "nvm version"
   nvm --version || echo "Use system's node insead of nvm"


### PR DESCRIPTION
In a container environment, we will not have sudo as a command
but the command is anyway started under root privileges. Hence
we can check if we are in a container and instead of performing

sudo /sbin/ldconfig

as done outside of the container we can just do

/sbin/ldconfig