### PR TITLE
Fix Handling of JSON PUT without accept header

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -91,6 +91,7 @@ const Router = {
       // or is a WebSocket request, or is multipart/form-data
       // treat it as an API request
       } else if (!request.accepts('html') && request.accepts('json') ||
+                 request.headers['content-type'] === 'application/json' ||
                  request.get('Upgrade') === 'websocket' ||
                  request.is('multipart/form-data') ||
                  request.path.startsWith(Constants.ADDONS_PATH) ||


### PR DESCRIPTION
Fix Handling of JSON PUT without accept header.  Use case linked to IFTTT webhook push failed as IFTT webhook does not add the Accepts: application/json header and sends Accepts: */* which results in improper handling of incoming api json PUT as gui PUT.