### PR TITLE
Only update changed properties

### DIFF
--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -345,6 +345,7 @@ class ThingModel extends Model {
    * @param {Object} data Property data
    */
   onPropertyStatus(data) {
+    const updatedProperties = {};
     for (const prop in data) {
       if (!this.propertyDescriptions.hasOwnProperty(prop)) {
         continue;
@@ -355,9 +356,14 @@ class ThingModel extends Model {
         continue;
       }
 
+      if (this.properties[prop] === value) {
+        continue;
+      }
+
       this.properties[prop] = value;
+      updatedProperties[prop] = value;
     }
-    return this.handleEvent(Constants.PROPERTY_STATUS, this.properties);
+    return this.handleEvent(Constants.PROPERTY_STATUS, updatedProperties);
   }
 
   /**

--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -356,10 +356,6 @@ class ThingModel extends Model {
         continue;
       }
 
-      if (this.properties[prop] === value) {
-        continue;
-      }
-
       this.properties[prop] = value;
       updatedProperties[prop] = value;
     }


### PR DESCRIPTION
This is the simplest way I found to fix the issue where if you're trying to change a color property and a different property updates on the same thing the input will lose your current value. I'm wary of any unexpected effects since this is at a pretty low level.