### PR TITLE
Remove Adapters settings menu item.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -70,7 +70,7 @@
           <li class="settings-item"><a id="network-settings-link" href="/settings/network">Network</a></li>
           <li class="settings-item"><a id="user-settings-link" href="/settings/users">Users</a></li>
           <li class="settings-item"><a id="addon-settings-link" href="/settings/addons">Add-ons</a></li>
-          <li class="settings-item"><a id="adapter-settings-link" href="/settings/adapters">Adapters</a></li>
+          <!-- <li class="settings-item"><a id="adapter-settings-link" href="/settings/adapters">Adapters</a></li> -->
           <li class="settings-item"><a id="update-settings-link" href="/settings/updates">Updates</a></li>
           <li class="settings-item"><a id="authorization-settings-link" href="/settings/authorizations">Authorizations</a></li>
           <li class="settings-item"><a id="experiment-settings-link" href="/settings/experiments">Experiments</a></li>


### PR DESCRIPTION
This leaves all the framework in place, since it will be reused
per #1976.

Fixes #1975