### PR TITLE
Open secondary captive portal after router setup.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -424,6 +424,11 @@ if (config.get('cli')) {
 // function to stop running server and start https
 TunnelService.switchToHttps = () => {
   stopHttpGateway();
+
+  if (platform.getOS() === 'linux-openwrt') {
+    RouterSetupApp.onSetupComplete();
+  }
+
   startHttpsGateway().then((server) => {
     TunnelService.setServerHandle(server);
   });

--- a/src/platforms/linux-openwrt.js
+++ b/src/platforms/linux-openwrt.js
@@ -347,6 +347,7 @@ function setCaptivePortalStatus(enabled, options = {}) {
         return false;
       }
     }
+
     if (!isRedirectedTcpPort(httpsSrcPort, httpsDstPort)) {
       if (!redirectTcpPort(enabled, options.ipaddr,
                            httpsSrcPort, httpsDstPort)) {
@@ -364,12 +365,27 @@ function setCaptivePortalStatus(enabled, options = {}) {
     addresses = [];
   }
   addresses = addresses.filter((value) => {
+    if (options.manualDnsAddresses) {
+      for (const opt of options.manualDnsAddresses) {
+        if (value.startsWith(`/${opt.host}/`)) {
+          return false;
+        }
+      }
+    }
+
     return !value.startsWith('/#/');
   });
 
   if (enabled) {
+    if (options.manualDnsAddresses) {
+      for (const opt of options.manualDnsAddresses) {
+        addresses.unshift(`/${opt.host}/${opt.address}`);
+      }
+    }
+
     addresses.unshift(`/#/${options.ipaddr}`);
   }
+
   // If addresses is an empty array, then uciSet will wind up deleting
   // the entry.
   if (!uciSet(label, 'dhcp.@dnsmasq[0].address', addresses)) {


### PR DESCRIPTION
This allows the user to configure the domain and user without
having to manually navigate to the gateway.

Fixes #1798