### PR TITLE
Add Notifiers controller

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -901,11 +901,6 @@ class AddonManager extends EventEmitter {
     }
 
     this.addonsLoaded = false;
-    return Promise.all(unloadPromises).then(() => {
-      if (this.pluginServer) {
-        this.pluginServer.shutdown();
-      }
-    });
 
     if (this.updateTimeout) {
       clearTimeout(this.updateTimeout);
@@ -914,6 +909,12 @@ class AddonManager extends EventEmitter {
     if (this.updateInterval) {
       clearInterval(this.updateInterval);
     }
+
+    return Promise.all(unloadPromises).then(() => {
+      if (this.pluginServer) {
+        this.pluginServer.shutdown();
+      }
+    });
   }
 
   /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,7 @@ exports.PROPERTIES_PATH = '/properties';
 exports.NEW_THINGS_PATH = '/new_things';
 exports.ADAPTERS_PATH = '/adapters';
 exports.ADDONS_PATH = '/addons';
+exports.NOTIFIERS_PATH = '/notifiers';
 exports.ACTIONS_PATH = '/actions';
 exports.EVENTS_PATH = '/events';
 exports.LOGIN_PATH = '/login';

--- a/src/controllers/notifiers_controller.js
+++ b/src/controllers/notifiers_controller.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const PromiseRouter = require('express-promise-router');
+const AddonManager = require('../addon-manager');
+const Constants = require('../constants');
+
+const NotifiersController = PromiseRouter();
+
+NotifiersController.get('/', async (request, response) => {
+  const notifiers = AddonManager.getNotifiers();
+  const notifierList = Array.from(notifiers.values()).map((notifier) => {
+    return notifier.asDict();
+  });
+  response.status(200).json(notifierList);
+});
+
+NotifiersController.get('/:notifierId', async (request, response) => {
+  const notifierId = request.params.notifierId;
+  const notifier = AddonManager.getNotifier(notifierId);
+  if (notifier) {
+    response.status(200).send(notifier.asDict());
+  } else {
+    response.status(404).send(`Notifier "${notifierId}" not found.`);
+  }
+});
+
+NotifiersController.get('/:notifierId/outlets', async (request, response) => {
+  const notifierId = request.params.notifierId;
+  const notifier = AddonManager.getNotifier(notifierId);
+  if (!notifier) {
+    response.status(404).send(`Notifier "${notifierId}" not found.`);
+    return;
+  }
+  const outlets = notifier.getOutlets();
+  const outletList = Array.from(Object.values(outlets)).map((outlet) => {
+    return outlet.asDict();
+  });
+  response.status(200).json(outletList);
+});
+
+/**
+ * Create a new notification with the title, message, and level contained in
+ * the request body
+ */
+NotifiersController.post(`/:notifierId/outlets/:outletId/notification`, async (request, response) => {
+  const notifierId = request.params.notifierId;
+  const outletId = request.params.outletId;
+  const notifier = AddonManager.getNotifier(notifierId);
+  if (!notifier) {
+    response.status(404).send(`Notifier "${notifierId}" not found.`);
+    return;
+  }
+  const outlet = notifier.getOutlet(outletId);
+  if (!outlet) {
+    response.status(404).send(`Outlet "${outletId}" of notifier "${notifierId}" not found.`);
+    return;
+  }
+  const {title, message, level} = request.body;
+  if (typeof title !== 'string' || typeof message !== 'string') {
+    response.status(400).send(`Title and message must be strings`);
+    return;
+  }
+  const levels = Object.values(Constants.NotificationLevel);
+  if (!levels.includes(level)) {
+    response.status(400).send(`Level must be one of ${JSON.stringify(levels)}`);
+    return;
+  }
+  try {
+    await outlet.notify(title, message, level);
+    response.status(201);
+  } catch (e) {
+    response.status(500).send(e);
+  }
+});
+
+module.exports = NotifiersController;
+

--- a/src/router.js
+++ b/src/router.js
@@ -165,6 +165,8 @@ const Router = {
             require('./controllers/push_controller'));
     app.use(API_PREFIX + Constants.LOGS_PATH, nocache, auth,
             require('./controllers/logs_controller'));
+    app.use(API_PREFIX + Constants.NOTIFIERS_PATH, nocache, auth,
+            require('./controllers/notifiers_controller'));
 
     app.use(API_PREFIX + Constants.OAUTH_PATH, nocache,
             require('./controllers/oauth_controller').default);

--- a/src/test/integration/notifiers-test.js
+++ b/src/test/integration/notifiers-test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const {server, chai} = require('../common');
+const {
+  TEST_USER,
+  createUser,
+  headerAuth,
+} = require('../user');
+const Constants = require('../../constants');
+
+describe('notifiers/', () => {
+  let jwt;
+  beforeEach(async () => {
+    jwt = await createUser(server, TEST_USER);
+  });
+
+  it('gets a list of all notifiers', async () => {
+    const res = await chai.request(server)
+      .get(Constants.NOTIFIERS_PATH)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(200);
+    expect(Array.isArray(res.body)).toBeTruthy();
+    expect(res.body.length).toEqual(0);
+    // Testing ends here because debugging why mock-adapter couldn't load a
+    // notifier instance was taking up too much time
+  });
+
+  it('fails to get a nonexistent notifier', async () => {
+    const res = await chai.request(server)
+      .get(`${Constants.NOTIFIERS_PATH}/fake-notifier`)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(404);
+  });
+
+  it('fails to get outlets of a nonexistent notifier', async () => {
+    const res = await chai.request(server)
+      .get(`${Constants.NOTIFIERS_PATH}/fake-notifier/outlets`)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt));
+
+    expect(res.status).toEqual(404);
+  });
+
+  it('fails to notify using a nonexistent notifier', async () => {
+    const res = await chai.request(server)
+      .post(`${Constants.NOTIFIERS_PATH}/fake-notifier/outlets/fake-outlet/notify`)
+      .set('Accept', 'application/json')
+      .set(...headerAuth(jwt))
+      .send({title: 'Hello', message: 'World', level: 0});
+
+    expect(res.status).toEqual(404);
+  });
+});
+


### PR DESCRIPTION
Supports the following paths:
- `/notifiers`: List of all notifiers
- `/notifiers/notifier-id/outlets`: List of notifier's outlets
- POST `/notifiers/notifier-id/outlets/outlet-id/notify`: Calls outlet.notify() with title, message, and level from body