### PR TITLE
Fixed a typo in the addon-loader

### DIFF
--- a/src/addon-loader.js
+++ b/src/addon-loader.js
@@ -153,7 +153,7 @@ if (opt.argv.length != 1) {
 }
 const addonPath = opt.argv[0];
 
-loadAddon(addonPath, opt.verbose).catch((err) => {
+loadAddon(addonPath, opt.options.verbose).catch((err) => {
   console.error(err);
   process.exit(Constants.DONT_RESTART_EXIT_CODE);
 });


### PR DESCRIPTION
This was discovered by trying to run the addon-loader
with the -v flag