### PR TITLE
Tack 'Notification' on to the end of all notifier outlet blocks

### DIFF
--- a/static/js/rules/NotifierOutletBlock.js
+++ b/static/js/rules/NotifierOutletBlock.js
@@ -4,7 +4,8 @@ const BlockConfigureDropdown = require('./BlockConfigureDropdown');
 class NotifierOutletBlock extends RulePartBlock {
   constructor(ruleArea, onPresentationChange, onRuleUpdate, notifier, outlet,
               values) {
-    super(ruleArea, onPresentationChange, onRuleUpdate, outlet.name,
+    super(ruleArea, onPresentationChange, onRuleUpdate,
+          `${outlet.name} Notification`,
           '/optimized-images/thing-icons/notification.svg');
 
     this.notifier = notifier;

--- a/static/js/views/rule-screen.js
+++ b/static/js/views/rule-screen.js
@@ -676,7 +676,7 @@ const RuleScreen = {
         const noBlock = this.makeBlock(
           'notifier-outlet-block',
           '/optimized-images/thing-icons/notification.svg',
-          outlet.name);
+          `${outlet.name} Notification`);
         const onNotifierOutletBlockDown =
           this.onBlockDown.bind(
             this,


### PR DESCRIPTION
I can't find the discussion about this but I believe this was requested and I think it's a good addition even when it overflows:
<img width="400" alt="Screen Shot 2019-07-17 at 12 46 11 PM" src="https://user-images.githubusercontent.com/2776089/61394375-f45cf300-a890-11e9-84b8-b43d74c634b1.png">
