### PR TITLE
Default MultiLevelSwitch's unit property to blank

### DIFF
--- a/static/js/components/capability/multi-level-switch.js
+++ b/static/js/components/capability/multi-level-switch.js
@@ -89,6 +89,7 @@ class MultiLevelSwitchCapability extends BaseComponent {
     this._on = false;
     this._level = 0;
     this._precision = 0;
+    this._unit = '';
     this._onClick = this.__onClick.bind(this);
   }
 


### PR DESCRIPTION
Before:
<img width="160" alt="icon with 0undefined" src="https://user-images.githubusercontent.com/2776089/61659973-d3ccd880-ac96-11e9-9bc2-7b453929a418.png">

After:
<img width="155" alt="icon with 0" src="https://user-images.githubusercontent.com/2776089/61659971-d3344200-ac96-11e9-885e-480bfc317f72.png">

Really only necessary if you're like me and have tons of defunct things but theoretically useful for preventing a flash of undefined