### PR TITLE
Properly encode URL parameters in calls to registration server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ addons:
       - libudev-dev
 
 before_install:
-  - pyenv global system 3.6
+  - pyenv install 2.7
+  - pyenv install 3.6.3
+  - pyenv global system 3.6.3
 
 install:
   - git clone https://github.com/mozilla-iot/intent-parser


### PR DESCRIPTION
We were swallowing + signs in email addresses.