### PR TITLE
Integrate fluent with images, part 3 of 3

### DIFF
--- a/static/fluent/en-US/main.ftl
+++ b/static/fluent/en-US/main.ftl
@@ -150,7 +150,8 @@ context-menu-choose-icon = Choose icon...
 context-menu-save = Save
 context-menu-remove = Remove
 
-mozilla-iot = Mozilla IoT
+wordmark =
+  .alt = Mozilla IoT
 
 errors = Errors
 submit = Submit
@@ -383,3 +384,11 @@ gateway-unreachable = Gateway Unreachable
 more-information = More Information
 
 unsupported-field = Unsupported field schema
+
+component-icons-custom-src = /optimized-images/component-icons/custom.png
+component-icons-on-off-switch-src = /optimized-images/component-icons/on-off-switch.png
+component-icons-on-off-switch-on-src = /optimized-images/component-icons/on-off-switch-on.png
+component-icons-on-off-switch-off-src = /optimized-images/component-icons/on-off-switch-off.png
+component-icons-binary-sensor-on-src = /optimized-images/component-icons/binary-sensor-on.png
+component-icons-binary-sensor-off-src = /optimized-images/component-icons/binary-sensor-off.png
+thing-icons-thing-src = /optimized-images/thing-icons/thing.svg

--- a/static/index.html
+++ b/static/index.html
@@ -544,7 +544,7 @@
     <!-- Menu -->
     <div id="menu-scrim" class="hidden"></div>
     <nav id="main-menu" class="hidden">
-      <img id="menu-wordmark" data-l10n-id="mozilla-iot" src="/optimized-images/wordmark.svg" />
+      <img id="menu-wordmark" data-l10n-id="wordmark" src="/optimized-images/wordmark.svg" />
       <ul>
         <li><a id="assistant-menu-item" data-l10n-id="assistant-menu-item" href="/assistant" class="hidden" ></a></li>
         <li><a id="things-menu-item" data-l10n-id="things-menu-item" href="/things" class="selected"></a></li>

--- a/static/js/components/capability/binary-sensor.js
+++ b/static/js/components/capability/binary-sensor.js
@@ -10,43 +10,50 @@
 'use strict';
 
 const BaseComponent = require('../base-component');
+const fluent = require('../../fluent');
 
-const template = document.createElement('template');
-template.innerHTML = `
-  <style>
-    :host {
-      display: block;
-      contain: content;
-      text-align: center;
-      color: white;
-      font-size: 1.6rem;
-      cursor: default;
-    }
+let template;
+function createTemplate() {
+  template = document.createElement('template');
+  template.innerHTML = `
+    <style>
+      :host {
+        display: block;
+        contain: content;
+        text-align: center;
+        color: white;
+        font-size: 1.6rem;
+        cursor: default;
+      }
 
-    .webthing-binary-sensor-capability-icon {
-      width: 12.8rem;
-      height: 12.8rem;
-      border-radius: 6.4rem;
-      background-size: 12.8rem;
-      background-repeat: no-repeat;
-      transform: translate(0);
-      background-color: #5d9bc7;
-      background-image: url('/optimized-images/component-icons/binary-sensor.png');
-    }
+      .webthing-binary-sensor-capability-icon {
+        width: 12.8rem;
+        height: 12.8rem;
+        border-radius: 6.4rem;
+        background-size: 12.8rem;
+        background-repeat: no-repeat;
+        transform: translate(0);
+        background-color: #5d9bc7;
+        background-image: url('/optimized-images/component-icons/binary-sensor.png');
+      }
 
-    .webthing-binary-sensor-capability-icon.on {
-      background-image: url('/optimized-images/component-icons/binary-sensor-on.png');
-    }
+      .webthing-binary-sensor-capability-icon.on {
+        background-image: url('${fluent.getMessage('component-icons-binary-sensor-on-src')}');
+      }
 
-    .webthing-binary-sensor-capability-icon.off {
-      background-image: url('/optimized-images/component-icons/binary-sensor-off.png');
-    }
-  </style>
-  <div id="icon" class="webthing-binary-sensor-capability-icon"></div>
-`;
+      .webthing-binary-sensor-capability-icon.off {
+        background-image: url('${fluent.getMessage('component-icons-binary-sensor-off-src')}');
+      }
+    </style>
+    <div id="icon" class="webthing-binary-sensor-capability-icon"></div>
+  `;
+}
 
 class BinarySensorCapability extends BaseComponent {
   constructor() {
+    if (!template) {
+      createTemplate();
+    }
     super(template);
 
     this._icon = this.shadowRoot.querySelector('#icon');

--- a/static/js/components/capability/custom.js
+++ b/static/js/components/capability/custom.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const BaseComponent = require('../base-component');
+const fluent = require('../../fluent');
 
 const template = document.createElement('template');
 template.innerHTML = `
@@ -64,7 +65,7 @@ class CustomCapability extends BaseComponent {
 
   set iconHref(value) {
     if (!value) {
-      this._iconHref = '/optimized-images/component-icons/custom.png';
+      this._iconHref = fluent.getMessage('component-icons-custom-src');
       this._icon.classList.remove('custom-icon');
     } else {
       this._iconHref = value;

--- a/static/js/components/capability/on-off-switch.js
+++ b/static/js/components/capability/on-off-switch.js
@@ -10,43 +10,50 @@
 'use strict';
 
 const BaseComponent = require('../base-component');
+const fluent = require('../../fluent');
 
-const template = document.createElement('template');
-template.innerHTML = `
-  <style>
-    :host {
-      display: block;
-      contain: content;
-      text-align: center;
-      color: white;
-      font-size: 1.6rem;
-      cursor: default;
-    }
+let template;
+function createTemplate() {
+  template = document.createElement('template');
+  template.innerHTML = `
+    <style>
+      :host {
+        display: block;
+        contain: content;
+        text-align: center;
+        color: white;
+        font-size: 1.6rem;
+        cursor: default;
+      }
 
-    .webthing-on-off-switch-capability-icon {
-      width: 12.8rem;
-      height: 12.8rem;
-      border-radius: 6.4rem;
-      background-size: 12.8rem;
-      background-repeat: no-repeat;
-      transform: translate(0);
-      background-color: #5d9bc7;
-      background-image: url('/optimized-images/component-icons/on-off-switch.png');
-    }
+      .webthing-on-off-switch-capability-icon {
+        width: 12.8rem;
+        height: 12.8rem;
+        border-radius: 6.4rem;
+        background-size: 12.8rem;
+        background-repeat: no-repeat;
+        transform: translate(0);
+        background-color: #5d9bc7;
+        background-image: url('${fluent.getMessage('component-icons-on-off-switch-src')}');
+      }
 
-    .webthing-on-off-switch-capability-icon.on {
-      background-image: url('/optimized-images/component-icons/on-off-switch-on.png');
-    }
+      .webthing-on-off-switch-capability-icon.on {
+        background-image: url('${fluent.getMessage('component-icons-on-off-switch-on-src')}');
+      }
 
-    .webthing-on-off-switch-capability-icon.off {
-      background-image: url('/optimized-images/component-icons/on-off-switch-off.png');
-    }
-  </style>
-  <div id="icon" class="webthing-on-off-switch-capability-icon"></div>
-`;
+      .webthing-on-off-switch-capability-icon.off {
+        background-image: url('${fluent.getMessage('component-icons-on-off-switch-off-src')}');
+      }
+    </style>
+    <div id="icon" class="webthing-on-off-switch-capability-icon"></div>
+  `;
+}
 
 class OnOffSwitchCapability extends BaseComponent {
   constructor() {
+    if (!template) {
+      createTemplate();
+    }
     super(template);
 
     this._icon = this.shadowRoot.querySelector('#icon');

--- a/static/js/components/icon/custom.js
+++ b/static/js/components/icon/custom.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const BaseComponent = require('../base-component');
+const fluent = require('../../fluent');
 
 const template = document.createElement('template');
 template.innerHTML = `
@@ -55,7 +56,7 @@ class CustomIcon extends BaseComponent {
   }
 
   set iconHref(value) {
-    this._iconHref = value || '/optimized-images/thing-icons/thing.svg';
+    this._iconHref = value || fluent.getMessage('thing-icons-thing-src');
     this._icon.style.backgroundImage = `url("${this._iconHref}")`;
   }
 }

--- a/static/js/icons.js
+++ b/static/js/icons.js
@@ -10,10 +10,14 @@
 
 'use strict';
 
-const defaultIcon = '/optimized-images/thing-icons/thing.svg';
+const fluent = require('./fluent');
+
+function defaultIcon() {
+  return fluent.getMessage('thing-icons-thing-src');
+}
 
 function capabilityHasIcon(capability) {
-  return capabilityToIcon(capability) !== defaultIcon;
+  return capabilityToIcon(capability) !== defaultIcon();
 }
 
 function capabilityToIcon(capability) {
@@ -52,12 +56,12 @@ function capabilityToIcon(capability) {
       return '/optimized-images/thing-icons/alarm.svg';
     case 'Custom':
     default:
-      return defaultIcon;
+      return defaultIcon();
   }
 }
 
 function typeHasIcon(type) {
-  return typeToIcon(type) !== defaultIcon;
+  return typeToIcon(type) !== defaultIcon();
 }
 
 function typeToIcon(type) {
@@ -78,7 +82,7 @@ function typeToIcon(type) {
     case 'smartPlug':
       return '/optimized-images/thing-icons/smart_plug.svg';
     default:
-      return defaultIcon;
+      return defaultIcon();
   }
 }
 

--- a/static/js/rules/RuleCard.js
+++ b/static/js/rules/RuleCard.js
@@ -26,8 +26,8 @@ class RuleCard {
       this.elt.classList.add('invalid');
     }
 
-    let iconTrigger = '/optimized-images/thing-icons/thing.svg';
-    let iconEffect = '/optimized-images/thing-icons/thing.svg';
+    let iconTrigger = fluent.getMessage('thing-icons-thing-src');
+    let iconEffect = fluent.getMessage('thing-icons-thing-src');
 
     if (this.rule.trigger) {
       let trigger = this.rule.trigger;

--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -77,7 +77,7 @@ class Thing {
     this.selectedCapability = description.selectedCapability;
     this.layoutIndex = description.layoutIndex;
     this.iconHref = description.iconHref || '';
-    this.baseIcon = opts.baseIcon || '/optimized-images/thing-icons/thing.svg';
+    this.baseIcon = opts.baseIcon || fluent.getMessage('thing-icons-thing-src');
     this.format = format;
     this.displayedProperties = this.displayedProperties || {};
     this.displayedActions = this.displayedActions || {};


### PR DESCRIPTION
Followup to #2108 

Skips the domain icon because "www" seems already translated as a concept
Skips the wordmark because I'm not sure if that's a thing we would translate
Skips the floorplan svg because the whole upload thing is convoluted, it would be much better to rewrite it as a DOM element

In general all of the things I did translate would be better off as just some html/css instead of png/svg.
