### PR TITLE
Remove Tunnel Token and allow re-registration to the tunelling service.

### DIFF
--- a/tools/redo-tunnel-registration.sh
+++ b/tools/redo-tunnel-registration.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+sqlite3 "${MOZIOT_HOME}/config/db.sqlite3" "DELETE FROM settings WHERE key='notunnel';"
+rm -rf "${MOZIOT_HOME}/ssl/"
+sudo service mozilla-iot-gateway restart

--- a/tools/redo-tunnel-registration.sh
+++ b/tools/redo-tunnel-registration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
-sqlite3 "${MOZIOT_HOME}/config/db.sqlite3" "DELETE FROM settings WHERE key='notunnel';"
-rm -rf "${MOZIOT_HOME}/ssl/"
-sudo service mozilla-iot-gateway restart

--- a/tools/remove-tunnel-token.sh
+++ b/tools/remove-tunnel-token.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
+sqlite3 "${MOZIOT_HOME}/config/db.sqlite3" "DELETE FROM settings WHERE key='tunneltoken';"
+rm -rf "${MOZIOT_HOME}/ssl/"
+sudo service mozilla-iot-gateway restart

--- a/tools/remove-tunnel-token.sh
+++ b/tools/remove-tunnel-token.sh
@@ -2,5 +2,6 @@
 
 MOZIOT_HOME="${MOZIOT_HOME:=${HOME}/.mozilla-iot}"
 sqlite3 "${MOZIOT_HOME}/config/db.sqlite3" "DELETE FROM settings WHERE key='tunneltoken';"
+sqlite3 "${MOZIOT_HOME}/config/db.sqlite3" "DELETE FROM settings WHERE key='notunnel';"
 rm -rf "${MOZIOT_HOME}/ssl/"
 sudo service mozilla-iot-gateway restart


### PR DESCRIPTION
Added helper scripts to change the tunnel registration settings without reflashing the SD card. The `redo-tunnel-registration.sh` is for the time when the user skipped the `tunnel-registration`. And `remove-tunnel-token.sh` if the user wants to re-registration to a new tunnel subdomain.
Based on: https://discourse.mozilla.org/t/need-assistance-to-configure-remote-access-after-initial-setup/44011/2 
and 
https://discourse.mozilla.org/t/remote-tunnel-access-denied/43772/3

Let me know if any changes are required.