### PR TITLE
Split add-on config out in database.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5572,7 +5572,7 @@
       "dev": true
     },
     "gateway-addon": {
-      "version": "git+https://github.com/mozilla-iot/gateway-addon-node.git#26e6fdcf9a77ab8171b9b0eaa028aa04deaf36b6",
+      "version": "git+https://github.com/mozilla-iot/gateway-addon-node.git#c347e48d29933e144f20a51db65064fe21a4ef06",
       "from": "git+https://github.com/mozilla-iot/gateway-addon-node.git",
       "requires": {
         "ajv": "^6.10.2",

--- a/src/addon-loader.js
+++ b/src/addon-loader.js
@@ -70,18 +70,27 @@ async function loadAddon(addonPath, verbose) {
 
   // Get any saved settings for this add-on.
   const key = `addons.${manifest.name}`;
-  const savedSettings = await Settings.get(key);
-  const newSettings = Object.assign({}, manifest);
-  if (savedSettings) {
-    // Overwrite config values.
-    newSettings.moziot.config = Object.assign(manifest.moziot.config || {},
-                                              savedSettings.moziot.config);
-  } else if (!newSettings.moziot.hasOwnProperty('config')) {
-    newSettings.moziot.config = {};
+  const configKey = `addons.config.${manifest.name}`;
+  const obj = await Settings.get(key);
+
+  const newSettings = {
+    name: obj.name,
+    display_name: obj.displayName,
+    moziot: {
+      exec: obj.exec,
+    },
+  };
+
+  if (obj.schema) {
+    newSettings.moziot.schema = obj.schema;
+  }
+
+  const savedConfig = await Settings.get(configKey);
+  if (savedConfig) {
+    newSettings.moziot.config = savedConfig;
   }
 
   const pluginClient = new PluginClient(manifest.name, {verbose});
-
 
   return pluginClient.register()
     .catch((e) => {

--- a/src/db.js
+++ b/src/db.js
@@ -359,24 +359,6 @@ const Database = {
   },
 
   /**
-   * Get a list of add-on-related settings.
-   *
-   * @return {Promise<Array<Setting>>} resolves with a list of setting objects
-   */
-  getAddonSettings: async function() {
-    return new Promise((resolve, reject) => {
-      this.db.all('SELECT * FROM settings WHERE key LIKE "addons.%"',
-                  (err, rows) => {
-                    if (err) {
-                      reject(err);
-                    } else {
-                      resolve(rows);
-                    }
-                  });
-    });
-  },
-
-  /**
    * Create a user
    * @param {User} user
    * @return {Promise<User>}

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -57,14 +57,6 @@ const Settings = {
   }),
 
   /**
-   * Get an object of all add-on-related settings.
-   */
-  getAddonSettings: () => Database.getAddonSettings().catch((e) => {
-    console.error('Failed to get add-on settings');
-    throw e;
-  }),
-
-  /**
    * Get an object of all tunnel settings
    * @return {localDomain, mDNSstate, tunnelDomain}
    */

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -600,9 +600,7 @@ class Plugin {
 
     this.startPromise = Settings.get(key).then((savedSettings) => {
       if (!this.forceEnable &&
-          (!savedSettings ||
-           !savedSettings.moziot ||
-           !savedSettings.moziot.enabled)) {
+          (!savedSettings || !savedSettings.enabled)) {
         console.error(`Plugin ${this.pluginId} not enabled, so not starting.`);
         this.restart = false;
         this.process.p = null;

--- a/src/test/browser/test-utils.js
+++ b/src/test/browser/test-utils.js
@@ -34,12 +34,7 @@ module.exports.getAddons = async () => {
   const installedAddons = new Map();
   // Store a map of name->version.
   for (const s of res.body) {
-    try {
-      const settings = JSON.parse(s.value);
-      installedAddons.set(settings.name, settings);
-    } catch (err) {
-      console.error(`Failed to parse add-on settings: ${err}`);
-    }
+    installedAddons.set(s.name, s);
   }
   return installedAddons;
 };

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -221,6 +221,22 @@ const API = {
     });
   },
 
+  getAddonConfig: (addonName) => {
+    const headers = {
+      Authorization: `Bearer ${API.jwt}`,
+      Accept: 'application/json',
+    };
+    return fetch(`/addons/${encodeURIComponent(addonName)}/config`, {
+      headers,
+    }).then((response) => {
+      if (!response.ok) {
+        throw new Error(
+          'Unexpected response code while getting add-on config');
+      }
+      return response.json();
+    });
+  },
+
   setAddonConfig: (addonName, config) => {
     const headers = {
       Authorization: `Bearer ${API.jwt}`,

--- a/static/js/views/addon-config.js
+++ b/static/js/views/addon-config.js
@@ -22,8 +22,7 @@ class AddonConfig {
    * @param {Object} metadata metadata object.
    */
   constructor(id, metadata) {
-    this.schema = metadata.moziot.schema;
-    this.config = metadata.moziot.config;
+    this.schema = metadata.schema;
     this.id = id;
     this.name = metadata.name;
     this.container = document.getElementById('addon-config-settings');
@@ -45,7 +44,9 @@ class AddonConfig {
           page('/settings/addons');
         })
         .catch((err) => {
-          console.error(`Failed to set config add-on: ${this.name}\n${err}`);
+          console.error(
+            `Failed to set config for add-on: ${this.name}\n${err}`
+          );
           this.configForm.errorField.render([err]);
           this.configForm.submitButton.innerText =
             fluent.getMessage('addon-config-apply');
@@ -57,14 +58,20 @@ class AddonConfig {
    * Render AddonConfig view and add to DOM.
    */
   render() {
-    this.configForm = new SchemaForm(
-      this.schema,
-      `addon-config-${this.id}`,
-      this.name,
-      this.config,
-      this.handleApply.bind(this),
-      {submitText: fluent.getMessage('addon-config-apply')});
-    this.container.appendChild(this.configForm.render());
+    API.getAddonConfig(this.id)
+      .then((config) => {
+        this.configForm = new SchemaForm(
+          this.schema,
+          `addon-config-${this.id}`,
+          this.name,
+          config,
+          this.handleApply.bind(this),
+          {submitText: fluent.getMessage('addon-config-apply')});
+        this.container.appendChild(this.configForm.render());
+      })
+      .catch((err) => {
+        console.error(`Failed to get config for add-on: ${this.name}\n${err}`);
+      });
   }
 }
 

--- a/static/js/views/installed-addon.js
+++ b/static/js/views/installed-addon.js
@@ -26,11 +26,9 @@ class InstalledAddon {
    */
   constructor(metadata, installedAddonsMap, availableAddonsMap) {
     this.name = metadata.name;
-    this.displayName = metadata.display_name;
+    this.displayName = metadata.displayName;
     this.description = metadata.description;
-    if (typeof metadata.author === 'object') {
-      this.author = metadata.author.name;
-    } else if (typeof metadata.author === 'string') {
+    if (typeof metadata.author === 'string') {
       this.author = metadata.author.split('<')[0].trim();
     } else {
       this.author = fluent.getMessage('author-unknown');
@@ -39,10 +37,9 @@ class InstalledAddon {
     this.license =
       `/addons/${encodeURIComponent(this.name)}/license?jwt=${API.jwt}`;
     this.version = metadata.version;
-    this.type = metadata.moziot.type || 'adapter';
-    this.enabled = metadata.moziot.enabled;
-    this.config = metadata.moziot.config;
-    this.schema = metadata.moziot.schema;
+    this.type = metadata.type;
+    this.enabled = metadata.enabled;
+    this.schema = metadata.schema;
     this.updateUrl = null;
     this.updateVersion = null;
     this.updateChecksum = null;
@@ -215,7 +212,7 @@ class InstalledAddon {
       .then(() => {
         this.enabled = enabled;
         const addon = this.installedAddonsMap.get(this.name);
-        addon.moziot.enabled = enabled;
+        addon.enabled = enabled;
         if (this.enabled) {
           button.innerText = fluent.getMessage('disable');
           button.classList.remove('addon-settings-enable');

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -1424,8 +1424,7 @@ const SettingsScreen = {
       this.installedAddons.clear();
       for (const s of body) {
         try {
-          const settings = JSON.parse(s.value);
-          this.installedAddons.set(settings.name, settings);
+          this.installedAddons.set(s.name, s);
         } catch (err) {
           console.error(`Failed to parse add-on settings: ${err}`);
         }


### PR DESCRIPTION
Instead of storing the entire package manifest, plus an overlayed
config, in the database, we'll now store:
* A basic object with package info and enablement.
* A separate record with the config.

This will allow us to switch manifest formats in an easier fashion.