### PR TITLE
Allow add-ons to specify enabled in manifest.

### DIFF
--- a/src/addon-utils.js
+++ b/src/addon-utils.js
@@ -266,7 +266,7 @@ function loadPackageJson(packageName) {
     obj.schema = manifest.moziot.schema;
   }
 
-  if (process.env.NODE_ENV === 'test' && manifest.moziot.enabled) {
+  if (manifest.moziot.enabled) {
     obj.enabled = true;
   }
 
@@ -433,8 +433,7 @@ function loadManifestJson(packageName) {
     }
   }
 
-  if (process.env.NODE_ENV === 'test' &&
-      manifest.gateway_specific_settings.webthings.enabled) {
+  if (manifest.gateway_specific_settings.webthings.enabled) {
     obj.enabled = true;
   }
 


### PR DESCRIPTION
This restores previous functionality, such that we can pre-install
and enable certain add-ons in our images.

These are filtered at the addon-list level, such that we only allow
add-ons owned by "Mozilla IoT" to be enabled by default.