### PR TITLE
Add a data directory for add-ons.

### DIFF
--- a/src/addon-manager.js
+++ b/src/addon-manager.js
@@ -635,6 +635,16 @@ class AddonManager extends EventEmitter {
       return;
     }
 
+    const dataPath = path.join(UserProfile.dataDir, manifest.id);
+    try {
+      // Create the add-on data directory, if necessary
+      if (!fs.existsSync(dataPath)) {
+        fs.mkdirSync(dataPath);
+      }
+    } catch (e) {
+      console.error(`Failed to create add-on data directory ${dataPath}:`, e);
+    }
+
     const errorCallback = (packageId, err) => {
       console.error(`Failed to load add-on ${packageId}:`, err);
     };

--- a/src/plugin/plugin-server.js
+++ b/src/plugin/plugin-server.js
@@ -75,6 +75,7 @@ class PluginServer extends EventEmitter {
             userProfile: {
               baseDir: UserProfile.baseDir,
               configDir: UserProfile.configDir,
+              dataDir: UserProfile.dataDir,
               mediaDir: UserProfile.mediaDir,
               logDir: UserProfile.logDir,
               gatewayDir: UserProfile.gatewayDir,

--- a/src/user-profile.js
+++ b/src/user-profile.js
@@ -27,6 +27,7 @@ const Profile = {
       process.env.MOZIOT_HOME || config.get('profileDir')
     );
     this.configDir = path.join(this.baseDir, 'config');
+    this.dataDir = path.join(this.baseDir, 'data');
     this.sslDir = path.join(this.baseDir, 'ssl');
     this.uploadsDir = path.join(this.baseDir, 'uploads');
     this.mediaDir = path.join(this.baseDir, 'media');
@@ -78,6 +79,9 @@ const Profile = {
     // Create all required profile directories.
     if (!fs.existsSync(this.configDir)) {
       mkdirp.sync(this.configDir);
+    }
+    if (!fs.existsSync(this.dataDir)) {
+      mkdirp.sync(this.dataDir);
     }
     if (!fs.existsSync(this.sslDir)) {
       mkdirp.sync(this.sslDir);


### PR DESCRIPTION
Instead of creating arbitrary data files all over the user profile
directory, or using the gateway's database, each add-on should use
its own data directory.