### PR TITLE
Update build-image.sh

### DIFF
--- a/image/build-gateway.sh
+++ b/image/build-gateway.sh
@@ -54,14 +54,17 @@ export NVM_DIR="$HOME/.nvm"
 nvm install ${NODE_VERSION}
 nvm use ${NODE_VERSION}
 
+export npm_config_arch=${ARCH}
+export npm_config_target_arch=arm
+
 # Install development-specific node modules and prerun webpack
-(cd ${GATEWAY}; rm -rf node_modules; npm install --ignore-scripts; npm rebuild --arch=${ARCH} --target_arch=arm; node_modules/.bin/webpack)
+(cd ${GATEWAY}; rm -rf node_modules; npm install; node_modules/.bin/webpack)
 
 echo "DEV_BUILD=${DEV_BUILD}"
 if [ "${DEV_BUILD}" != "1" ]; then
   # Clear out node_modules just in case then build only the modules we'll use in
   # the image, cross compiling any native code.
-  (cd ${GATEWAY}; rm -rf node_modules; npm install --ignore-scripts --production; npm rebuild --arch=${ARCH} --target_arch=arm)
+  (cd ${GATEWAY}; rm -rf node_modules; npm install --production)
 fi
 
 set -x


### PR DESCRIPTION
Use environment variables to set the cross compile
architecture. This way we don't need to use --ignore-scripts
gateway-addon-node now uses git submodules are relies on
npm scripts to get the git repository checked out properly.

Fixes #2200