### PR TITLE
Drop es-MX translation.

### DIFF
--- a/static/fluent/es-MX/main.ftl
+++ b/static/fluent/es-MX/main.ftl
@@ -1,9 +1,0 @@
-## Menu Items
-assistant-menu-item = Asistente
-things-menu-item = Cosas
-rules-menu-item = Reglas
-logs-menu-item = Registros
-floorplan-menu-item = Plano de Planta
-settings-menu-item = Configuración
-log-out-button = Cerrar sesión
-

--- a/static/js/fluent.js
+++ b/static/js/fluent.js
@@ -4,7 +4,6 @@ const Fluent = require('@fluent/bundle');
 
 const availableLanguages = {
   'en-US': ['/fluent/en-US/main.ftl'],
-  // 'es-MX': ['/fluent/es-MX/main.ftl'],
   en: ['/fluent/en-US/main.ftl'],
   it: ['/fluent/it/main.ftl'],
 };


### PR DESCRIPTION
It's almost completely empty and was only used during development.