### PR TITLE
Use the compat build of Fluent.js to support Microsoft Edge

### DIFF
--- a/static/js/fluent.js
+++ b/static/js/fluent.js
@@ -1,6 +1,6 @@
 const API = require('./api');
-const FluentDOM = require('@fluent/dom');
-const Fluent = require('@fluent/bundle');
+const FluentDOM = require('@fluent/dom/compat');
+const Fluent = require('@fluent/bundle/compat');
 
 const availableLanguages = {
   'en-US': ['/fluent/en-US/main.ftl'],


### PR DESCRIPTION
Currently, the current version of Microsoft Edge doesn't work with the gateway. The [readme.md states that Edge 14+ is supported](https://github.com/mozilla-iot/gateway#browser-support). Currently, the regular build of Fluent.js doesn't support Microsoft Edge, and [requires the `compat` build to be used](https://github.com/projectfluent/fluent.js/issues/431). This PR should fix the Edge support.