### PR TITLE
Switch certificate renewal to dns-01 challenge.

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -67,10 +67,6 @@ const Router = {
       }
     });
 
-    // Allow LE challenges, used when renewing domain.
-    const acmeHandler = express.static(Constants.BUILD_STATIC_PATH);
-    app.use('/.well-known/acme-challenge', acmeHandler);
-
     // Content negotiation middleware
     app.use((request, response, next) => {
       // Inform the browser that content negotiation is taking place

--- a/src/ssltunnel.js
+++ b/src/ssltunnel.js
@@ -1,5 +1,5 @@
 /**
- * MozIoT Gateway Tunnelservice.
+ * Gateway tunnel service.
  *
  * Manages the tunnel service.
  *
@@ -127,11 +127,13 @@ const TunnelService = {
           // Enable push service
           PushService.init(`https://${endpoint}`);
 
+          const renew = () => {
+            return CertificateManager.renew(this.server).catch(() => {});
+          };
+
           // Try to renew certificates immediately, then daily.
-          CertificateManager.renew(this.server).then(() => {
-            this.renewInterval = setInterval(() => {
-              CertificateManager.renew(this.server);
-            }, 24 * 60 * 60 * 1000);
+          renew().then(() => {
+            this.renewInterval = setInterval(renew, 24 * 60 * 60 * 1000);
           });
         }).catch(() => {});
       } else {


### PR DESCRIPTION
If the certificate expired before being renewed, the http-01
challenge would never complete since Let's Encrypt wouldn't
verify the expired certificate, and we don't allow plain HTTP.

Fixes #2260