### PR TITLE
Review Italian localization

### DIFF
--- a/static/fluent/it/main.ftl
+++ b/static/fluent/it/main.ftl
@@ -16,7 +16,7 @@ log-out-button = Disconnettersi
 
 ## Assistant
 assistant-avatar-image =
-  .alt = Assistente Avatar
+  .alt = Avatar assistente
 assistant-controls-text-input =
   .placeholder = Come posso aiutare?
 
@@ -28,7 +28,7 @@ upload-floorplan-hint = (.svg raccomandato)
 settings-domain = Dominio
 settings-network = Rete
 settings-users = Utenti
-settings-add-ons = Add-ons
+settings-add-ons = Componenti aggiuntivi
 settings-adapters = Adattatori
 settings-localization = Localizzazione
 settings-updates = Aggiornamenti
@@ -63,7 +63,7 @@ network-settings-ip-address = Indirizzo IP
 network-settings-dhcp = Automatico (DHCP)
 network-settings-static = Manuale (IP statico)
 network-settings-pppoe = Bridge (PPPoE)
-network-settings-static-ip-address = Indirizzo IP Statico
+network-settings-static-ip-address = Indirizzo IP statico
 network-settings-network-mask = Maschera di rete
 network-settings-gateway = Gateway
 network-settings-done = Fatto
@@ -75,13 +75,13 @@ network-settings-username = Username
 network-settings-password = Password
 network-settings-router-ip = Indirizzo IP del router
 network-settings-dhcp-server = Server DHCP
-network-settings-enable-wifi = Abilita Wi-Fi
+network-settings-enable-wifi = Attiva Wi-Fi
 network-settings-network-name = Nome di rete (SSID)
 wireless-connected = Connesso
 wireless-icon =
   .alt = Rete Wi-Fi
-network-settings-changing = Modifica delle impostazioni di rete. Questo potrebbe richiedere un minuto.
-failed-ethernet-configure = Impossibile configurare Ethernet.
+network-settings-changing = Modifica delle impostazioni di rete. Questa operazione potrebbe richiedere un minuto.
+failed-ethernet-configure = Impossibile configurare ethernet.
 failed-wifi-configure = Impossibile configurare Wi-Fi.
 failed-wan-configure = Impossibile configurare WAN.
 failed-lan-configure = Impossibile configurare LAN.
@@ -100,8 +100,8 @@ user-settings-input-confirm-new-password =
   .placeholder = Conferma nuova password
 user-settings-input-confirm-password =
   .placeholder = Conferma password
-user-settings-password-mismatch = Le passwords non corrispondono
-user-settings-save = Salvare
+user-settings-password-mismatch = Le password non corrispondono
+user-settings-save = Salva
 
 ## Adapter Settings
 adapter-settings-no-adapters = Nessun adattatore presente
@@ -110,11 +110,11 @@ adapter-settings-no-adapters = Nessun adattatore presente
 authorization-settings-no-authorizations = Nessuna autorizzazione
 
 ## Experiment Settings
-experiment-settings-smart-assistant = Smart Assistente
+experiment-settings-smart-assistant = Assistente smart
 experiment-settings-logs = Registri
 
 ## Localization Settings
-localization-settings-language-region = Lingua e Regione
+localization-settings-language-region = Lingua e regione
 localization-settings-country = Nazione
 localization-settings-timezone = Fuso orario
 localization-settings-language = Lingua
@@ -126,16 +126,16 @@ localization-settings-units-temperature-fahrenheit = Temperatura Fahrenheit
 ## Update Settings
 update-settings-update-now = Aggiorna ora
 update-available = Aggiornamento disponibile
-update-up-to-date = Aggiorna aggiornato
+update-up-to-date = Il sistema è aggiornato
 last-update = Ultimo aggiornamento
 current-version = Versione corrente
-failed = Mancato
+failed = Non riuscito
 never = Mai
 in-progress = In corso
-restarting = Ripresa
+restarting = Riprendi
 
 ## Developer Settings
-developer-settings-enable-ssh = Abilita SSH
+developer-settings-enable-ssh = Attiva SSH
 developer-settings-view-internal-logs = Visualizza registri interni
 developer-settings-create-local-authorization = Crea autorizzazione locale
 
@@ -151,25 +151,25 @@ rules-preview-button =
 rules-delete-icon =
   .alt = Elimina
 rules-drag-hint = Trascina qui i tuoi dispositivi per iniziare a creare una regola
-rules-drag-input-hint = Aggiungi dispositivo come input
-rules-drag-output-hint = Aggiungi dispositivo come output
+rules-drag-input-hint = Aggiungi dispositivo come ingresso (input)
+rules-drag-output-hint = Aggiungi dispositivo come uscita (output)
 rules-scroll-left =
   .alt = Scorri verso sinistra
 rules-scroll-right =
   .alt = Scorri verso destra
-rules-delete-prompt = Rilascia qui i dispositivi per disconnetterti
-rules-delete-dialog = Sei sicuro di voler rimuovere questa regola in modo permanente?
+rules-delete-prompt = Rilascia qui i dispositivi per disconnetterli
+rules-delete-dialog = Rimuovere questa regola in modo permanente?
 rules-delete-cancel =
   .value = Annulla
 rules-delete-confirm =
   .value = Rimuovi regola
 rule-invalid = Non valido
-rule-delete-prompt = Sei sicuro di voler rimuovere questa regola in modo permanente?
+rule-delete-prompt = Rimuovere questa regola in modo permanente?
 rule-delete-cancel-button =
   .value = Annulla
 rule-delete-confirm-button =
   .value = Rimuovi regola
-rule-select-property = Selezione
+rule-select-property = Seleziona
 rule-not = Non
 rule-event = Evento
 rule-action = Azione
@@ -185,7 +185,7 @@ notification-high = Alto
 rule-name = Nome
 rule-and = e
 rule-or = o
-rule-time-of-day-is = l'ora del giorno è
+rule-time-of-day-is = l’ora del giorno è
 rule-event-lower = evento
 rule-event-occurs = verifica
 
@@ -198,27 +198,26 @@ logs-device-select =
 logs-property = Proprietà
 logs-property-select =
   .aria-label = Proprietà registro
-logs-retention = Ritenzione
+logs-retention = Conservazione
 logs-retention-length =
-  .aria-label = Registro lunghezza di ritenzione
+  .aria-label = Durata del periodo di conservazione
 logs-retention-unit =
-  .aria-label = Registro unità di ritenzione
+  .aria-label = Unità di misura del periodo di conservazione
 logs-hours = Ore
 logs-days = Giorni
 logs-weeks = Settimane
-logs-save = Salvare
+logs-save = Salva
 logs-remove-dialog-title = Rimozione
-logs-remove-dialog-warning = La rimozione del registro rimuoverà anche tutti i suoi dati.
- Sei sicuro di volerlo rimuovere?
-logs-remove = Rimuovere
+logs-remove-dialog-warning = La rimozione del registro cancellerà anche tutti i dati inclusi. Procedere con la rimozione?
+logs-remove = Rimuovi
 logs-unable-to-create = Impossibile creare il registro
 logs-server-remove-error = Errore del server: impossibile rimuovere il registro
 
 ## Add New Things
 add-thing-scanning-icon =
-  .alt = Scansione
-add-thing-scanning = Scansione per nuovi dispositivi…
-add-thing-add-adapters-hint = Non sono state trovate nuove cose. Provare
+  .alt = Ricerca
+add-thing-scanning = Ricerca di nuovi dispositivi…
+add-thing-add-adapters-hint = Non sono stati trovati nuovi oggetti. Provare
 add-thing-add-adapters-hint-anchor = ad aggiungere alcuni componenti aggiuntivi.
 add-thing-add-by-url = Aggiungi per URL…
 add-thing-done = Fatto
@@ -226,17 +225,17 @@ add-thing-cancel = Annulla
 
 ## Context Menu
 context-menu-choose-icon = Scegli icona…
-context-menu-save = Salvare
-context-menu-remove = Rimuovere
+context-menu-save = Salva
+context-menu-remove = Rimuovi
 
 ## Capabilities
-OnOffSwitch = Interruttore acceso spento
+OnOffSwitch = Interruttore acceso/spento
 MultiLevelSwitch = Interruttore multi livello
 ColorControl = Controllo del colore
 ColorSensor = Sensore di colore
 EnergyMonitor = Sensore energia
 BinarySensor = Sensore binario
-MultiLevelSensor = Sensore multi livello
+MultiLevelSensor = Sensore multilivello
 SmartPlug = Presa elettrica smart
 Light = Luce
 DoorSensor = Sensore porta
@@ -244,18 +243,18 @@ MotionSensor = Sensore di movimento
 LeakSensor = Sensore di perdite
 PushButton = Pulsante
 VideoCamera = Videocamera
-Camera = Telecamera
+Camera = Fotocamera
 TemperatureSensor = Sensore temperatura
 Alarm = Allarme
 Thermostat = Termostato
 Lock = Serratura
-Custom = Unico
+Custom = Personalizzato
 
 ## Properties
 alarm = Allarme
 pushed = Spinto
 not-pushed = Non spinto
-on-off = Acceso Spento
+on-off = Acceso/spento
 on = Acceso
 off = Spento
 power = Energia
@@ -268,25 +267,25 @@ brightness = Luminosità
 leak = Perdita
 dry = Asciutto
 color-temperature = Temperatura di colore
-video-unsupported = Il video non è supportato nel suo browser.
+video-unsupported = Il video non è supportato nel browser.
 motion = Movimento
 no-motion = Nessun movimento
 open = Aperto
 closed = Chiuso
 locked = Bloccato
 unlocked = Sbloccato
-jammed = Inceppata
+jammed = Inceppato
 unknown = Sconosciuto
 
 ## Domain Setup
-reclaim-prompt = Sembra che abbia già registrato quel sottodominio. Per reclamarlo
-click-here = clicca qui
-check-email-for-token = Controlla la sua e-mail per un token di recupero e incollalo sopra.
+reclaim-prompt = Sembra che questo sottodominio sia già stato registrato. Per recuperarlo
+click-here = fai clic qui
+check-email-for-token = Controlla l’e-mail per un token di recupero e incollalo sopra.
 reclaim-failed = Impossibile recuperare il dominio.
-subdomain-already-used = Questo sottodominio è già in uso. Per favore scegline uno diverso.
+subdomain-already-used = Questo sottodominio è già in uso. Scegli un altro dominio.
 invalid-reclamation-token = Token di recupero non valido.
-domain-success = Successo! Per favore attendi di essere reindirizzato…
-issuing-error = Errore durante l'emissione del certificato. Per favore, riprova.
+domain-success = Operazione conclusa. Reindirizzamento in corso…
+issuing-error = Errore durante l’emissione del certificato. Riprova.
 redirecting = Reindirizzamento…
 
 ## Booleans
@@ -359,50 +358,50 @@ unknown-device-type = Tipo di dispositivo sconosciuto
 new-thing-choose-icon = Scegli icona…
 new-thing-save = Salva
 new-thing-pin =
-  .placeholder = Inserisci pin
-new-thing-pin-error = PIN scorretto
+  .placeholder = Inserisci PIN
+new-thing-pin-error = PIN non corretto
 new-thing-pin-invalid = PIN non valido
 new-thing-cancel = Annulla
-new-thing-submit = Sottoscrivi
+new-thing-submit = Invia
 new-thing-username =
-  .placeholder = Inserire username
+  .placeholder = Inserisci il nome utente
 new-thing-password =
-  .placeholder = Inserire la password
+  .placeholder = Inserisci la password
 new-thing-credentials-error = Credenziali errate
 new-thing-saved = Salvato
 new-thing-done = Fatto
 
 ## New Web Thing View
 new-web-thing-url =
-  .placeholder = Inserisci l'URL della web thing
-new-web-thing-label = Web Thing
+  .placeholder = Inserisci l’URL del l’oggetto web
+new-web-thing-label = Oggetto web
 loading = Caricamento in corso…
-new-web-thing-multiple = Molti web things
+new-web-thing-multiple = Diversi oggetti web rilevati
 new-web-thing-from = da
 
 ## Empty div Messages
-no-things = Nessun dispositivo ancora. Fai clic su + per cercare i dispositivi disponibili.
-thing-not-found = Web Thing non trovato.
+no-things = Nessun dispositivo. Fai clic su + per cercare i dispositivi disponibili.
+thing-not-found = Oggetto web non trovato.
 action-not-found = Azione non trovata.
-events-not-found = Questa web thing non ha eventi.
+events-not-found = Questo oggetto non ha eventi.
 
 ## Add-on Settings
 author-unknown = Sconosciuto
-disable = Disattivare
-enable = Abilitare
+disable = Disattiva
+enable = Abilita
 by = di
-addon-configure = Configurazione
-addon-update = Aggiornare
-addon-remove = Rimuovere
-addon-updating = In aggiornamento
+addon-configure = Configura
+addon-update = Aggiorna
+addon-remove = Rimuovi
+addon-updating = Aggiornamento in corso…
 addon-updated = Aggiornato
-addon-update-failed = Mancato
-addon-config-applying = L'applicazione
-addon-config-apply = Applicare
+addon-update-failed = Non riuscito
+addon-config-applying = Applicazione in corso…
+addon-config-apply = Applica
 addon-discovery-added = Aggiunto
 addon-discovery-add = Inserisci
-addon-discovery-installing = Installazione
-addon-discovery-failed = Mancato
+addon-discovery-installing = Installazione in corso…
+addon-discovery-failed = Non riuscito
 
 ## Page Titles
 settings = Impostazioni
@@ -411,29 +410,29 @@ users = Utenti
 edit-user = Modifica utente
 add-user = Aggiungi utente
 adapters = Adattori
-addons = Add-ons
-addon-config = Configurazione del add-on
-addon-discovery = Scopri add-ons
+addons = Componenti aggiuntivi
+addon-config = Configura componente aggiuntivo
+addon-discovery = Scopri componenti aggiuntivi
 experiments = Esperimenti
 localization = Localizzazione
 updates = Aggiornamenti
-authorizations = Le autorizzazioni
-developer = Sviluppare
+authorizations = Autorizzazioni
+developer = Sviluppo
 network = Rete
 ethernet = Ethernet
 wifi = Wi-Fi
 icon = Icona
 
 ## Speech
-speech-unsupported = Il browser corrente non supporta il parlato.
-speech-didnt-get = Mi dispiace, non l'ho capito.
+speech-unsupported = Il browser corrente non supporta i comandi vocali.
+speech-didnt-get = Mi dispiace, non ho capito.
 
 ## Errors
 unknown-state = Stato sconosciuto.
 error = Errore
 errors = Errori
 gateway-unreachable = Gateway non raggiungibile
-more-information = Maggiori informazioni
+more-information = Ulteriori informazioni
 invalid-file = File non valido
 failed-read-file = Impossibile leggere il file.
 failed-save = Impossibile salvare il file.
@@ -451,45 +450,45 @@ login-log-in = Accesso
 ## Create First User Page
 signup-title = Crea utente — WebThings Gateway
 signup-welcome = Benvenuto
-signup-create-account = Crea il suo primo account utente:
+signup-create-account = Crea il tuo primo account utente:
 signup-password-mismatch = Le password non corrispondono
-signup-next = Il prossimo
+signup-next = Successivo
 
 ## Tunnel Setup Page
-tunnel-setup-title = Scegli Indirizzo Web — WebThings Gateway
+tunnel-setup-title = Scegli indirizzo web — WebThings Gateway
 tunnel-setup-welcome = Benvenuto
 tunnel-setup-choose-address = Scegli un indirizzo web sicuro per il suo gateway:
 tunnel-setup-input-subdomain =
   .placeholder = sottodominio
-tunnel-setup-opt-in = Tienimi aggiornato sulle nuove funzionalità e sulle opportunità di contributo.
-tunnel-setup-privacy-policy = Politica sulla riservatezza
+tunnel-setup-opt-in = Tienimi aggiornato sulle nuove funzionalità e sulle opportunità di collaborazione.
+tunnel-setup-privacy-policy = Informativa sulla privacy
 tunnel-setup-input-reclamation-token =
-  .placeholder = Token di bonifica
-tunnel-setup-error = Si è verificato un errore durante l'impostazione del sottodominio.
-tunnel-setup-create = Creare
-tunnel-setup-skip = Salta
-tunnel-setup-time-sync = In attesa che l’orologio di sistema venga impostato da Internet. È probabile che la registrazione del dominio non riesca fino al completamento.
+  .placeholder = Token di recupero
+tunnel-setup-error = Si è verificato un errore durante l’impostazione del sottodominio.
+tunnel-setup-create = Crea
+tunnel-setup-skip = Ignora
+tunnel-setup-time-sync = In attesa che l’orologio di sistema venga impostato da Internet. È possibile che la registrazione del dominio non riesca fino al completamento dell’operazione.
 
 ## Authorize Page
 authorize-title = Richiesta di autorizzazione — WebThings Gateway
 authorize-authorization-request = Richiesta di autorizzazione
-authorize-would-like = Vorresti accedere al suo gateway
+authorize-would-like = Vorresti accedere al gateway
 authorize-devices = dispositivi
 authorize-from = da
 authorize-monitor-and-control = Monitorare e controllare
 authorize-monitor = monitorare
-authorize-allow-all = Consenti a tutte Things
+authorize-allow-all = Consenti tutti gli oggetti
 authorize-allow =
-  .value = Permettere
-authorize-deny = Negare
+  .value = Permetti
+authorize-deny = Nega
 
 ## Local Token Page
 local-token-title = Servizio token locale — WebThings Gateway
 local-token-header = Servizio token locale
-local-token-your-token = Il token locale è questo
+local-token-your-token = Il token locale è:
 local-token-jwt = JSON Web Token
-local-token-use-it = Usalo per parlare in modo sicuro con il gateway, con
-local-token-bearer-type = Bearer-type autorizzazione
+local-token-use-it = Usalo per comunicare in modo sicuro con il gateway, con
+local-token-bearer-type = autorizzazione Bearer-type
 
 ## Router Setup Page
 router-setup-title = Configurazione del router — WebThings Gateway
@@ -501,7 +500,7 @@ router-setup-input-password =
 router-setup-input-confirm-password =
   .placeholder = Conferma password
 router-setup-create =
-  .value = Creare
+  .value = Crea
 router-setup-password-mismatch = Le password devono essere identiche
 
 ## Wi-Fi Setup Page
@@ -511,35 +510,30 @@ wifi-setup-input-password =
   .placeholder = Password
 wifi-setup-show-password = Mostra password
 wifi-setup-connect =
-  .value = Collegare
+  .value = Connetti
 wifi-setup-network-icon =
   .alt = Rete Wi-Fi
-wifi-setup-skip = Salta
+wifi-setup-skip = Ignora
 
 ## Connecting to Wi-Fi Page
 connecting-title = Connessione al Wi-Fi — WebThings Gateway
 connecting-header = Connessione al Wi-Fi…
-connecting-connect = Effettuare una connessione alla stessa rete e
- quindi va a { $gateway-link } nel suo browser web per continuare l'installazione.
-connecting-warning = Se non riesci a caricare { $domain }, inserisci l'indirizzo IP del gateway.
+connecting-connect = Assicursi di essere connessi alla stessa rete e aprire { $gateway-link } nel browser per proseguire l’installazione.
+connecting-warning = Se non è possibile aprire { $domain }, inserire l’indirizzo IP del gateway.
 connecting-header-skipped = Configurazione Wi-Fi ignorata
-connecting-skipped = Il gateway è in fase di avvio. Navigare verso
- { $gateway-link } nel suo browser web per continuare l'installazione.
- (Con connessione di rete uguale al gateway.)
+connecting-skipped = Il gateway è in fase di avvio. Connettersi alla stessa rete del gateway e aprire { $gateway-link } nel browser per proseguire l’installazione.
 
 ## Creating Wi-Fi Network Page
 creating-title = Creazione della rete Wi-Fi — WebThings Gateway
 creating-header = Creazione della rete Wi-Fi…
-creating-content = Effettua una connessione a { $ssid } con la password che ha appena
- creato, quindi va a { $gateway-link } o { $ip-link } nel suo Web
- browser.
+creating-content = Connettersi a { $ssid } con la password appena creata, quindi aprire { $gateway-link } o { $ip-link } nel browser.
 
 ## General Terms
-ok = Ok
+ok = OK
 ellipsis = …
 event-log = Registro eventi
-edit = Modificare
-remove = Rimuovere
-disconnected = Scollegato
-processing = In lavorazione…
-submit = Sottoscrivi
+edit = Modifica
+remove = Rimuovi
+disconnected = Disconnesso
+processing = In elaborazione…
+submit = Invia


### PR DESCRIPTION
CC @kgiori 

In only looked at the Italian file as part of bug 1596535. A few general notes:
- We drop courtesy forms in Italian
- Buttons are actions (imperative, e.g. "Salva"), not descriptive ("Salvare")

See also #2326. It's unclear if "Web Thing" should be localizable or not.

There might be some other things to fix, but that would be easier on Pontoon, where both source and localization are available.

Talking about Pontoon: once that's set up, we need to understand if the community takes over ownership, or if you want to keep maintaining the localization. We can chat about it in Slack, and happy to answer any questions about the changes.
