### PR TITLE
Fix caching issues after updates.

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -199,6 +199,44 @@ h1, h2, h3, h4, h5, h6 {
   display: none;
 }
 
+#update-message-area {
+  position: fixed;
+  top: 3rem;
+  width: 33%;
+  left: calc(33% - 1rem);
+  background-color: rgba(76, 124, 160, 0.6);
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  color: white;
+  font-size: 2rem;
+  transform: translateY(0);
+  transition: transform 0.25s ease;
+  z-index: 100;
+}
+
+#update-message-area-text {
+  padding-bottom: 2rem;
+}
+
+#update-message-area > button {
+  background-color: #48779a;
+  font-size: 1.8rem;
+}
+
+#update-message-area > button:hover,
+#update-message-area > button:active {
+  background-color: #658196;
+}
+
+#update-message-area-reload {
+  margin-right: 1rem;
+}
+
+#update-message-area.hidden {
+  transform: translateY(-100%) translateY(-4rem);
+}
+
 #message-area {
   position: fixed;
   bottom: 3rem;
@@ -226,6 +264,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 @media only screen and (max-width: 730px) {
+  #update-message-area,
   #message-area {
     width: calc(100% - 10rem);
     left: 3rem;

--- a/static/fluent/en-US/main.ftl
+++ b/static/fluent/en-US/main.ftl
@@ -598,6 +598,11 @@ creating-title = Creating Wi-Fi Network — { -webthings-gateway-brand }
 creating-header = Creating Wi-Fi network…
 creating-content = Please connect to { $ssid } with the password you just created, then navigate to { $gateway-link } or { $ip-link } in your web browser.
 
+## UI Updates
+ui-update-available = An updated user interface is available.
+ui-update-reload = Reload
+ui-update-close = Close
+
 ## General Terms
 
 ok = Ok

--- a/static/index.html
+++ b/static/index.html
@@ -599,6 +599,11 @@
 
     <!-- Message area -->
     <div id="message-area" class="hidden"></div>
+    <div id="update-message-area" class="hidden">
+      <div id="update-message-area-text" data-l10n-id="ui-update-available"></div>
+      <button id="update-message-area-reload" class="text-button" data-l10n-id="ui-update-reload"></button>
+      <button id="update-message-area-close" class="text-button" data-l10n-id="ui-update-close"></button>
+    </div>
 
     <!-- Add Thing Screen -->
     <div id="add-thing-screen" class="hidden dialog">

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -4,6 +4,10 @@
 // eslint-disable-next-line no-undef
 const CACHE = `mozilla-iot-cache-${VERSION}`;
 
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) => {


### PR DESCRIPTION
New service workers are only loaded in specific cases. This PR
gives the user the ability to reload it on the fly.

Fixes #2289