### PR TITLE
Send thing changes over WebSockets.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -51,6 +51,7 @@ exports.API_HANDLER_ADDED = 'apiHandlerAdded';
 exports.CONNECTED = 'connected';
 exports.ERROR = 'error';
 exports.EVENT = 'event';
+exports.MODIFIED = 'modified';
 exports.NOTIFIER_ADDED = 'notifierAdded';
 exports.OUTLET_ADDED = 'outletAdded';
 exports.OUTLET_REMOVED = 'outletRemoved';
@@ -61,6 +62,7 @@ exports.REMOVED = 'removed';
 exports.REQUEST_ACTION = 'requestAction';
 exports.SET_PROPERTY = 'setProperty';
 exports.THING_ADDED = 'thingAdded';
+exports.THING_MODIFIED = 'thingModified';
 exports.THING_REMOVED = 'thingRemoved';
 
 // OAuth things

--- a/src/models/thing.js
+++ b/src/models/thing.js
@@ -210,7 +210,11 @@ class Thing {
   setCoordinates(x, y) {
     this.floorplanX = x;
     this.floorplanY = y;
-    return Database.updateThing(this.id, this.getDescription());
+    return Database.updateThing(this.id, this.getDescription())
+      .then((descr) => {
+        this.emitter.emit(Constants.MODIFIED);
+        return descr;
+      });
   }
 
   /**
@@ -221,7 +225,11 @@ class Thing {
    */
   setLayoutIndex(index) {
     this.layoutIndex = index;
-    return Database.updateThing(this.id, this.getDescription());
+    return Database.updateThing(this.id, this.getDescription())
+      .then((descr) => {
+        this.emitter.emit(Constants.MODIFIED);
+        return descr;
+      });
   }
 
   /**
@@ -232,7 +240,11 @@ class Thing {
    */
   setTitle(title) {
     this.title = title;
-    return Database.updateThing(this.id, this.getDescription());
+    return Database.updateThing(this.id, this.getDescription())
+      .then((descr) => {
+        this.emitter.emit(Constants.MODIFIED);
+        return descr;
+      });
   }
 
   /**
@@ -300,7 +312,11 @@ class Thing {
     this.iconHref = path.join('/uploads', path.basename(tempfile.name));
 
     if (updateDatabase) {
-      return Database.updateThing(this.id, this.getDescription());
+      return Database.updateThing(this.id, this.getDescription())
+        .then((descr) => {
+          this.emitter.emit(Constants.MODIFIED);
+          return descr;
+        });
     }
   }
 
@@ -312,7 +328,11 @@ class Thing {
    */
   setSelectedCapability(capability) {
     this.selectedCapability = capability;
-    return Database.updateThing(this.id, this.getDescription());
+    return Database.updateThing(this.id, this.getDescription())
+      .then((descr) => {
+        this.emitter.emit(Constants.MODIFIED);
+        return descr;
+      });
   }
 
   /**
@@ -358,6 +378,22 @@ class Thing {
    */
   removeConnectedSubscription(callback) {
     this.emitter.removeListener(Constants.CONNECTED, callback);
+  }
+
+  /**
+   * Add a subscription to the Thing's modified state
+   * @param {Function} callback
+   */
+  addModifiedSubscription(callback) {
+    this.emitter.on(Constants.MODIFIED, callback);
+  }
+
+  /**
+   * Remove a subscription to the Thing's modified state
+   * @param {Function} callback
+   */
+  removeModifiedSubscription(callback) {
+    this.emitter.removeListener(Constants.MODIFIED, callback);
   }
 
   /**
@@ -477,6 +513,8 @@ class Thing {
    * @return {Promise} A promise which resolves with the description set.
    */
   updateFromDescription(description) {
+    const oldDescription = JSON.stringify(this.getDescription());
+
     // Update @context
     this['@context'] =
       description['@context'] || 'https://iot.mozilla.org/schemas';
@@ -630,7 +668,15 @@ class Thing {
       this.selectedCapability = '';
     }
 
-    return Database.updateThing(this.id, this.getDescription());
+    return Database.updateThing(this.id, this.getDescription())
+      .then((descr) => {
+        const newDescription = JSON.stringify(this.getDescription());
+        if (newDescription !== oldDescription) {
+          this.emitter.emit(Constants.MODIFIED);
+        }
+
+        return descr;
+      });
   }
 
   /**

--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -132,6 +132,10 @@ class ThingModel extends Model {
             this.cleanup();
           }
           break;
+        case 'thingRemoved':
+          this.handleEvent(Constants.DELETE_THING, this.id);
+          this.cleanup();
+          break;
       }
     };
 

--- a/static/js/views/floorplan.js
+++ b/static/js/views/floorplan.js
@@ -86,6 +86,10 @@ const FloorplanScreen = {
   },
 
   refreshThings: function(things) {
+    if (this.view.classList.contains('edit')) {
+      return;
+    }
+
     let thing;
     while (typeof (thing = this.things.pop()) !== 'undefined') {
       this.removeInteract(thing);

--- a/static/js/views/things.js
+++ b/static/js/views/things.js
@@ -225,6 +225,11 @@ const ThingsScreen = {
 
     this.refreshThing = () => {
       return App.gatewayModel.getThing(thingId).then(async (description) => {
+        if (!description) {
+          this.thingsElement.innerHTML = fluent.getMessage('thing-not-found');
+          return;
+        }
+
         this.thingsElement.innerHTML = '';
 
         const thingModel = await App.gatewayModel.getThingModel(thingId);


### PR DESCRIPTION
Notify WebSocket listeners of thing additions, removals, and
modifications. This helps keep multiple UIs in sync with one
another.

References mozilla-iot/wot#133