### PR TITLE
Add support for ColorModeProperty for lights.

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -487,6 +487,7 @@ require('./components/property/alarm');
 require('./components/property/boolean');
 require('./components/property/brightness');
 require('./components/property/color');
+require('./components/property/color-mode');
 require('./components/property/color-temperature');
 require('./components/property/current');
 require('./components/property/enum');

--- a/static/js/components/capability/light.js
+++ b/static/js/components/capability/light.js
@@ -105,10 +105,12 @@ class LightCapability extends BaseComponent {
     this._haveBrightness = false;
     this._haveColor = false;
     this._haveColorTemperature = false;
+    this._haveColorMode = false;
     this._on = false;
     this._brightness = 0;
     this._color = OFF_FILL;
     this._colorTemperature = 2700;
+    this._colorMode = 'color';
 
     this._onClick = this.__onClick.bind(this);
   }
@@ -126,6 +128,10 @@ class LightCapability extends BaseComponent {
       typeof this.dataset.haveColorTemperature !== 'undefined' ?
         this.dataset.haveColorTemperature === 'true' :
         false;
+    this._haveColorMode =
+      typeof this.dataset.haveColorMode !== 'undefined' ?
+        this.dataset.haveColorMode === 'true' :
+        false;
     this.on = typeof this.dataset.on !== 'undefined' ? this.dataset.on : false;
     this.brightness =
       typeof this.dataset.brightness !== 'undefined' ?
@@ -136,6 +142,10 @@ class LightCapability extends BaseComponent {
       typeof this.dataset.colorTemperature !== 'undefined' ?
         this.dataset.colorTemperature :
         2700;
+    this.colorMode =
+      typeof this.dataset.colorMode !== 'undefined' ?
+        this.dataset.colorMode :
+        'color';
     this._container.addEventListener('click', this._onClick);
   }
 
@@ -164,10 +174,8 @@ class LightCapability extends BaseComponent {
       this._label.innerText = fluent.getMessage('off');
     }
 
-    if (this._haveColor) {
-      this.color = this._color;
-    } else if (this._haveColorTemperature) {
-      this.colorTemperature = this._colorTemperature;
+    if (this._haveColor || this._haveColorTmperature) {
+      this._updateIconColor();
     } else if (this._on) {
       this._icon.style.fill = ON_FILL;
     } else {
@@ -203,7 +211,7 @@ class LightCapability extends BaseComponent {
     }
 
     this._color = value;
-    this._updateIconColor(value);
+    this._updateIconColor();
   }
 
   get colorTemperature() {
@@ -216,10 +224,40 @@ class LightCapability extends BaseComponent {
     }
 
     this._colorTemperature = Number(value);
-    this._updateIconColor(Utils.colorTemperatureToRGB(this._colorTemperature));
+    this._updateIconColor();
   }
 
-  _updateIconColor(value) {
+  get colorMode() {
+    return this._colorMode;
+  }
+
+  set colorMode(value) {
+    if (!this._haveColorMode) {
+      return;
+    }
+
+    this._colorMode = value;
+    this._updateIconColor();
+  }
+
+  _updateIconColor() {
+    let value;
+    if (this._haveColorMode) {
+      if (this.colorMode === 'color') {
+        value = this.color;
+      } else if (this.colorMode === 'temperature') {
+        value = Utils.colorTemperatureToRGB(this.colorTemperature);
+      } else {
+        value = ON_FILL;
+      }
+    } else if (this._haveColor) {
+      value = this.color;
+    } else if (this._haveColorTemperature) {
+      value = Utils.colorTemperatureToRGB(this.colorTemperature);
+    } else {
+      value = ON_FILL;
+    }
+
     this._icon.style.fill = value;
 
     const r = parseInt(value.substr(1, 2), 16);

--- a/static/js/components/property/color-mode.js
+++ b/static/js/components/property/color-mode.js
@@ -1,0 +1,22 @@
+/**
+ * ColorModeProperty
+ *
+ * A bubble showing a color mode label.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+'use strict';
+
+const StringLabelProperty = require('./string-label');
+
+class ColorModeProperty extends StringLabelProperty {
+  connectedCallback() {
+    this.uppercase = true;
+    super.connectedCallback();
+  }
+}
+
+window.customElements.define('webthing-color-mode-property', ColorModeProperty);
+module.exports = ColorModeProperty;

--- a/static/js/schema-impl/capability/light.js
+++ b/static/js/schema-impl/capability/light.js
@@ -39,6 +39,7 @@ class Light extends OnOffSwitch {
     this.brightnessProperty = null;
     this.colorProperty = null;
     this.colorTemperatureProperty = null;
+    this.colorModeProperty = null;
 
     // Look for properties by type first.
     for (const name in this.displayedProperties) {
@@ -51,6 +52,9 @@ class Light extends OnOffSwitch {
       } else if (this.colorTemperatureProperty === null &&
                  type === 'ColorTemperatureProperty') {
         this.colorTemperatureProperty = name;
+      } else if (this.colorModeProperty === null &&
+                 type === 'ColorModeProperty') {
+        this.colorModeProperty = name;
       }
     }
 
@@ -68,6 +72,11 @@ class Light extends OnOffSwitch {
     if (this.colorTemperatureProperty === null &&
         this.displayedProperties.hasOwnProperty('colorTemperature')) {
       this.colorTemperatureProperty = 'colorTemperature';
+    }
+
+    if (this.colorModeProperty === null &&
+        this.displayedProperties.hasOwnProperty('colorMode')) {
+      this.colorModeProperty = 'colorMode';
     }
   }
 
@@ -95,15 +104,23 @@ class Light extends OnOffSwitch {
     } else if (name === this.colorTemperatureProperty) {
       value = parseInt(value, 10);
       this.icon.colorTemperature = value;
+    } else if (name === this.colorModeProperty) {
+      this.icon.colorMode = value;
     }
   }
 
   iconView() {
     let color = '';
     if (this.colorProperty !== null) {
-      color = 'data-have-color="true"';
-    } else if (this.colorTemperatureProperty !== null) {
-      color = 'data-have-color-temperature="true"';
+      color += ' data-have-color="true"';
+    }
+
+    if (this.colorTemperatureProperty !== null) {
+      color += ' data-have-color-temperature="true"';
+    }
+
+    if (this.colorModeProperty !== null) {
+      color += ' data-have-color-mode="true"';
     }
 
     let brightness = '';

--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -17,6 +17,7 @@ const App = require('../../app');
 const BooleanDetail = require('../property/boolean');
 const BrightnessDetail = require('../property/brightness');
 const ColorDetail = require('../property/color');
+const ColorModeDetail = require('../property/color-mode');
 const ColorTemperatureDetail = require('../property/color-temperature');
 const Constants = require('../../constants');
 const CurrentDetail = require('../property/current');
@@ -189,6 +190,9 @@ class Thing {
             break;
           case 'ColorProperty':
             detail = new ColorDetail(this, name, convertedProperty);
+            break;
+          case 'ColorModeProperty':
+            detail = new ColorModeDetail(this, name, convertedProperty);
             break;
           case 'ColorTemperatureProperty':
             detail = new ColorTemperatureDetail(this, name, convertedProperty);

--- a/static/js/schema-impl/property/color-mode.js
+++ b/static/js/schema-impl/property/color-mode.js
@@ -1,0 +1,41 @@
+/**
+ * ColorModeDetail
+ *
+ * A bubble showing color mode.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const StringLabelDetail = require('./string-label');
+const Utils = require('../../utils');
+const fluent = require('../../fluent');
+
+class ColorModeDetail extends StringLabelDetail {
+  constructor(thing, name, property) {
+    super(thing, name, !!property.readOnly,
+          property.title || fluent.getMessage('off'));
+    this.id = `color-mode-${Utils.escapeHtmlForIdClass(this.name)}`;
+  }
+
+  view() {
+    return `
+      <webthing-color-mode-property
+        data-read-only="true" data-name="${Utils.escapeHtml(this.label)}"
+        id="${this.id}">
+      </webthing-color-mode-property>`;
+  }
+
+  update(value) {
+    if (!this.label) {
+      return;
+    }
+
+    this.labelElement.value = `${value}`.toUpperCase();
+  }
+}
+
+module.exports = ColorModeDetail;


### PR DESCRIPTION
This allows the icon to display either color temperature, or RGB
color, depending on which mode it's in.

References mozilla-iot/schemas#64