### PR TITLE
Simplify device removal.

### DIFF
--- a/src/controllers/debug_controller.js
+++ b/src/controllers/debug_controller.js
@@ -57,11 +57,7 @@ debugController.get('/adapters', (request, response) => {
  * Add a new device
  */
 debugController.get('/addNewThing', (request, response) => {
-  addonManager.addNewThing(60).then((thing) => {
-    console.log('debugController: addNewThing added thing', thing);
-  }, () => {
-    console.log('debugController: addNewThing cancelled');
-  });
+  addonManager.addNewThing(60);
   response.sendStatus(204);
 });
 
@@ -270,17 +266,8 @@ debugController.put('/thing/:thingId/:propertyName', (request, response) => {
  */
 debugController.get('/removeThing/:thingId', (request, response) => {
   const thingId = request.params.thingId;
-  addonManager.removeThing(thingId).then((thingIdRemoved) => {
-    console.log('debugController: removed', thingIdRemoved);
-    if (thingId != thingIdRemoved) {
-      console.log('debugController: Actually removed', thingIdRemoved,
-                  'even though request was for:', thingId);
-    }
-    response.status(200).json({removed: thingIdRemoved});
-  }, (str) => {
-    console.log('debugController: remove failed:', str);
-    response.status(500).send(`remove of ${thingId} failed: ${str}`);
-  });
+  addonManager.removeThing(thingId);
+  response.status(200).json({removed: thingId});
 });
 
 /**

--- a/src/controllers/things_controller.js
+++ b/src/controllers/things_controller.js
@@ -381,20 +381,13 @@ ThingsController.put('/:thingId', async (request, response) => {
  */
 ThingsController.delete('/:thingId', (request, response) => {
   const thingId = request.params.thingId;
-  AddonManager.removeThing(thingId).
-    // removedThingId isn't necessarily the same as thingId (for example,
-    // with the ZWave adapter, the user could request to remove one thing,
-    // but actually push the button on a different thing).
-    then((removedThingId) => {
-      Things.removeThing(removedThingId).then(() => {
-        console.log(`Successfully deleted ${removedThingId} from database.`);
-        response.sendStatus(204);
-      }).catch((e) => {
-        response.status(500).send(`Failed to remove thing ${removedThingId}: ${e}`);
-      });
-    }).catch((e) => {
-      response.status(500).send(`Failed to remove thing ${thingId}: ${e}`);
-    });
+  AddonManager.removeThing(thingId);
+  Things.removeThing(thingId).then(() => {
+    console.log(`Successfully deleted ${thingId} from database.`);
+    response.sendStatus(204);
+  }).catch((e) => {
+    response.status(500).send(`Failed to remove thing ${thingId}: ${e}`);
+  });
 });
 
 function websocketHandler(websocket, request) {


### PR DESCRIPTION
In cases where removal and pairing cannot overlap, such as Z-Wave,
those cases need to be handled by the add-on.

Fixes #1013
Fixes #1252