### PR TITLE
Fix issue with creating multiple OAuth tokens.

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -34,7 +34,8 @@ self.addEventListener('fetch', (event) => {
       url.pathname.endsWith('.map') ||
       url.pathname.endsWith('floorplan.svg') ||
       url.pathname.startsWith('/internal-logs') ||
-      url.pathname.startsWith('/extensions')) {
+      url.pathname.startsWith('/extensions') ||
+      url.pathname.startsWith('/oauth/allow')) {
     return;
   }
 


### PR DESCRIPTION
The service worker was caching the response, so the user could
only create one token per browser session.