### PR TITLE
[doc] use `npm ci` to restrict dependencies to lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ python3 -m pip install git+https://github.com/mozilla-iot/gateway-addon-python#e
 * Install dependencies:
 
     ```
-    $ npm install
+    $ npm ci
     ```
 
 * Add Firewall exceptions (Fedora Linux Only)


### PR DESCRIPTION
Rather than installing dependencies that are allowed within semver ranges of dependencies specified in `package.json`. Use `npm ci` to restrict installation to the dependencies specified in `package-lock.json`. This should prevent unexpected issues arising from installs/builds from source for dependencies that are known to work. 

