### PR TITLE
fix(addon-loader) Print an error when `npm-link` fails

### DIFF
--- a/src/addon-loader.js
+++ b/src/addon-loader.js
@@ -93,13 +93,17 @@ async function loadAddon(addonPath, verbose) {
           'gateway-addon'
         );
         if (!fs.existsSync(modulePath)) {
-          spawnSync(
+          const link = spawnSync(
             'npm',
             ['link', 'gateway-addon'],
             {
               cwd: addonPath,
             }
           );
+
+          if (link.error) {
+            console.log(`Failed to npm-link the gateway-addon package: ${link.error}`);
+          }
         }
 
         const addonLoader = dynamicRequire(addonPath);


### PR DESCRIPTION
When installing the gateway on my setup, `npm link` failed because of a permission issue. The error was silent. With this patch, the error appears, and it could help the user to fix the issue.