### PR TITLE
Fix Wi-Fi icon being squeezed in Chrome

### DIFF
--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -326,6 +326,7 @@
 
 .network-settings-list-item-icon {
   height: 6rem;
+  width: 6rem;
   padding: 2rem 2rem;
 }
 


### PR DESCRIPTION
In desktop and Android Chrome v81 Wi-Fi icon in "Settings" has a strange aspect ratio.

**Before**:
<img width="588" alt="Screenshot 2020-05-23 at 20 52 34" src="https://user-images.githubusercontent.com/15949146/82738771-957eca80-9d3a-11ea-9b2a-e5f4622d82f6.png">

**After**:
<img width="587" alt="Screenshot 2020-05-23 at 20 52 46" src="https://user-images.githubusercontent.com/15949146/82738773-9a437e80-9d3a-11ea-85d9-79ad0c7b564b.png">

Checked the fix in Chrome and Firefox - looks fine in both browsers.

Fixes #2079