### PR TITLE
Add search box for available add-ons

### DIFF
--- a/static/fluent/en-US/main.ftl
+++ b/static/fluent/en-US/main.ftl
@@ -458,6 +458,8 @@ addon-discovery-added = Added
 addon-discovery-add = Add
 addon-discovery-installing = Installing…
 addon-discovery-failed = Failed
+addon-search =
+    .placeholder = Search
 
 ## Page Titles
 

--- a/static/index.html
+++ b/static/index.html
@@ -386,6 +386,9 @@
         <section id="addon-config-settings" class="hidden settings-subsection">
         </section>
         <section id="addon-discovery-settings" class="hidden settings-subsection">
+          <div class="section-title-container">
+            Search: <input id="discover-addons-search"></input>
+          </div>
           <ul id="discovered-addons-list">
           </ul>
         </section>

--- a/static/index.html
+++ b/static/index.html
@@ -387,7 +387,7 @@
         </section>
         <section id="addon-discovery-settings" class="hidden settings-subsection">
           <div class="section-title-container">
-            Search: <input id="discover-addons-search"></input>
+            <input id="discover-addons-search" data-l10n-id="addon-search"></input>
           </div>
           <ul id="discovered-addons-list">
           </ul>

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -1676,7 +1676,8 @@ const SettingsScreen = {
 
     const searchText = this.discoverAddonsSearch.value.toLowerCase();
 
-    const matches = (x) => x.name.toLowerCase().indexOf(searchText) > -1 ||
+    const matches = (x) => x.id.toLowerCase().indexOf(searchText) > -1 ||
+                           x.name.toLowerCase().indexOf(searchText) > -1 ||
                            x.description.toLowerCase().indexOf(searchText) > -1;
 
     Array.from(this.availableAddons.entries())

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -50,6 +50,8 @@ const SettingsScreen = {
     this.addonConfigSettings = document.getElementById('addon-config-settings');
     this.discoverAddonsButton =
       document.getElementById('discover-addons-button');
+    this.discoverAddonsSearch =
+      document.getElementById('discover-addons-search');
     this.experimentSettings = document.getElementById('experiment-settings');
     this.localizationSettings =
       document.getElementById('localization-settings');
@@ -108,6 +110,10 @@ const SettingsScreen = {
 
     this.discoverAddonsButton.addEventListener('click', () => {
       page('/settings/addons/discovered');
+    });
+    this.discoverAddonsSearch.addEventListener('input', () => {
+      console.log(this.discoverAddonsSearch.value);
+      this.updateDiscoveredAddonsList();
     });
     this.addUserButton.addEventListener('click', () => {
       page('/settings/users/add');
@@ -1660,15 +1666,25 @@ const SettingsScreen = {
     this.fetchInstalledAddonList(false).then(() => {
       return this.fetchAvailableAddonList(false);
     }).then(() => {
-      const addonList = document.getElementById('discovered-addons-list');
-      addonList.innerHTML = '';
-
-      Array.from(this.availableAddons.entries())
-        .sort((a, b) => a[1].name.localeCompare(b[1].name))
-        .forEach((x) => new DiscoveredAddon(x[1],
-                                            this.installedAddons,
-                                            this.availableAddons));
+      this.updateDiscoveredAddonsList();
     }).catch(console.error);
+  },
+
+  updateDiscoveredAddonsList: function() {
+    const addonList = document.getElementById('discovered-addons-list');
+    addonList.innerHTML = '';
+
+    const searchText = this.discoverAddonsSearch.value.toLowerCase();
+
+    const matches = (x) => x.name.toLowerCase().indexOf(searchText) > -1 ||
+                           x.description.toLowerCase().indexOf(searchText) > -1;
+
+    Array.from(this.availableAddons.entries())
+      .filter((x) => matches(x[1]))
+      .sort((a, b) => a[1].name.localeCompare(b[1].name))
+      .forEach((x) => new DiscoveredAddon(x[1],
+                                          this.installedAddons,
+                                          this.availableAddons));
   },
 
   showExperimentCheckbox: (experiment, checkboxId) => {

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -115,7 +115,6 @@ const SettingsScreen = {
       this.discoverAddonsSearch.value = '';
     });
     this.discoverAddonsSearch.addEventListener('input', () => {
-      console.log(this.discoverAddonsSearch.value);
       this.updateDiscoveredAddonsList();
     });
     this.addUserButton.addEventListener('click', () => {

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -1676,9 +1676,11 @@ const SettingsScreen = {
 
     const searchText = this.discoverAddonsSearch.value.toLowerCase();
 
-    const matches = (x) => x.id.toLowerCase().indexOf(searchText) > -1 ||
-                           x.name.toLowerCase().indexOf(searchText) > -1 ||
-                           x.description.toLowerCase().indexOf(searchText) > -1;
+    const contains = (a, b) => a.toLowerCase().indexOf(b.toLowerCase()) > -1;
+
+    const matches = (x) => contains(x.id, searchText) ||
+                           contains(x.name, searchText) ||
+                           contains(x.description, searchText);
 
     Array.from(this.availableAddons.entries())
       .filter((x) => matches(x[1]))

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -111,6 +111,9 @@ const SettingsScreen = {
     this.discoverAddonsButton.addEventListener('click', () => {
       page('/settings/addons/discovered');
     });
+    this.backButton.addEventListener('click', () => {
+      this.discoverAddonsSearch.value = '';
+    });
     this.discoverAddonsSearch.addEventListener('input', () => {
       console.log(this.discoverAddonsSearch.value);
       this.updateDiscoveredAddonsList();

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -1680,7 +1680,8 @@ const SettingsScreen = {
 
     const matches = (x) => contains(x.id, searchText) ||
                            contains(x.name, searchText) ||
-                           contains(x.description, searchText);
+                           contains(x.description, searchText) ||
+                           contains(x.primary_type, searchText);
 
     Array.from(this.availableAddons.entries())
       .filter((x) => matches(x[1]))


### PR DESCRIPTION
Adds a search box for case insensitive client-side filtering of installable add-ons.
The supplied input is matched against the name and the description of the add-on.

fixes #1932