### PR TITLE
Fix some annoyances with rule editor.

### DIFF
--- a/static/css/rule.css
+++ b/static/css/rule.css
@@ -77,9 +77,14 @@
   padding-bottom: 0;
 }
 
+#rule-view .rule-info h1 .rule-name {
+  padding: 0 1rem;
+}
+
 #rule-view .rule-info > p {
   font-size: 1.6rem;
   margin-top: 0.8rem;
+  padding-left: 1rem;
   color: #DAE3EB;
 }
 

--- a/static/js/rules/BlockConfigureDropdown.js
+++ b/static/js/rules/BlockConfigureDropdown.js
@@ -187,6 +187,7 @@ class BlockConfigureDropdown {
       node = node.parentNode;
     }
     this.elt.classList.remove('open');
+    document.activeElement.blur();
     this.onCommit();
   }
 

--- a/static/js/rules/NotifierOutletBlock.js
+++ b/static/js/rules/NotifierOutletBlock.js
@@ -21,9 +21,10 @@ class NotifierOutletBlock extends RulePartBlock {
       this.values = values;
     }
 
-    const configureContainer = this.elt.querySelector('.rule-part-info');
+    const blockContainer = this.elt.querySelector('.rule-part-block');
+    const infoContainer = this.elt.querySelector('.rule-part-info');
     this.updateValues = this.updateValues.bind(this);
-    this.dropdown = new BlockConfigureDropdown(this, configureContainer);
+    this.dropdown = new BlockConfigureDropdown(this, infoContainer);
     this.dropdown.addValue({
       id: 'title',
       title: fluent.getMessage('notification-title'),
@@ -48,7 +49,15 @@ class NotifierOutletBlock extends RulePartBlock {
       enum: this.levels,
       value: this.levels[this.values.level],
     });
+    blockContainer.addEventListener('click', this.onBlockClick.bind(this));
+    infoContainer.addEventListener('click', this.onBlockClick.bind(this));
     this.updateRulePart();
+  }
+
+  onBlockClick() {
+    if (!this.dropdown.elt.classList.contains('open')) {
+      this.dropdown.onCommit();
+    }
   }
 
   updateValues(values) {

--- a/static/js/rules/PropertySelect.js
+++ b/static/js/rules/PropertySelect.js
@@ -252,6 +252,9 @@ class PropertySelect {
         this.devicePropertyBlock.rulePart = ruleFragment;
         this.devicePropertyBlock.onRuleChange();
         elt.dataset.ruleFragment = JSON.stringify(ruleFragment);
+
+        // select this property, since it's been changed
+        this.select(elt);
       });
     } else if (property.type === 'string') {
       let valueInput, valueSelect;
@@ -308,6 +311,9 @@ class PropertySelect {
           this.devicePropertyBlock.rulePart = ruleFragment;
           this.devicePropertyBlock.onRuleChange();
         }
+
+        // select this property, since it's been changed
+        this.select(elt);
       });
     }
 
@@ -546,6 +552,8 @@ class PropertySelect {
   onClick(e) {
     this.elt.classList.toggle('open');
     if (!this.elt.classList.contains('open')) {
+      document.activeElement.blur();
+
       let target = e.target;
       if (!target.classList.contains('property-select-option')) {
         target = target.parentNode;
@@ -619,6 +627,7 @@ class PropertySelect {
       node = node.parentNode;
     }
     this.elt.classList.remove('open');
+    document.activeElement.blur();
   }
 
   remove() {

--- a/static/js/rules/RulePartBlock.js
+++ b/static/js/rules/RulePartBlock.js
@@ -55,6 +55,7 @@ class RulePartBlock {
     const openSelector = this.elt.querySelector('.open');
     if (openSelector) {
       openSelector.classList.remove('open');
+      document.activeElement.blur();
     }
 
     this.resetState = {


### PR DESCRIPTION
* Add some padding to rule title so that it's easier to select the
  end of the input string.
* Save notifier outlet effect when clicking on the block, rather
  than just outside of the block.
* Select a property input/output when an input is changed, rather
  than forcing the user to also click the property name.

Fixes #718