### PR TITLE
Open internal logs in same window

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -464,7 +464,7 @@
             <label for="enable-ssh-checkbox" data-l10n-id="developer-settings-enable-ssh"></label>
           </li>
           <li class="developer-link-item">
-            <a id="view-internal-logs" href="#" target="_blank" rel="noopener"
+            <a id="view-internal-logs" href="#" rel="noopener"
                data-l10n-id="developer-settings-view-internal-logs"></a>
           </li>
           <li class="developer-link-item">


### PR DESCRIPTION
On touch screen kiosk systems there is no tab management. If a user opens the internal logs, they get 'stuck' in a new window. 
Swiping from the left to go back doesn't work in a fresh tab. But it would work if the logs were opened in the same window.