### PR TITLE
Open license in same window

### DIFF
--- a/static/js/views/installed-addon.js
+++ b/static/js/views/installed-addon.js
@@ -80,7 +80,7 @@ class InstalledAddon {
             ${fluent.getMessage('by')} <a href="${this.homepageUrl}" target="_blank" rel="noopener">${Utils.escapeHtml(this.author)}</a>
           </span>
           <span class="addon-settings-license">
-            (<a href="${this.licenseUrl}" target="_blank" rel="noopener">license</a>)
+            (<a href="${this.licenseUrl}" rel="noopener">license</a>)
           </span>
         </div>
         <div class="addon-settings-controls">


### PR DESCRIPTION
For touch screen kiosk users, opening a new tab can lead to complications. The 'back' button no longer works. And since the license is shown as a text file, there is no 'close' button to close the new tab.

If the license if shown in the same tab, then the 'swipe to go back' funtionality still works, and users can get back to the UI.

Perhaps an even more optimal solution would be to load the license in an overlay.