### PR TITLE
Unhide delete button on rule page

### DIFF
--- a/static/css/rule.css
+++ b/static/css/rule.css
@@ -30,7 +30,6 @@
 }
 
 #delete-button {
-  display: none; /* TODO */
   background: none;
   border: 0;
   width: 9.6rem;

--- a/static/js/views/rule-screen.js
+++ b/static/js/views/rule-screen.js
@@ -92,6 +92,7 @@ const RuleScreen = {
 
     this.deleteConfirm.addEventListener('click', () => {
       this.rule.delete().then(() => {
+        this.deleteOverlay.classList.remove('active');
         page('/rules');
       });
     });


### PR DESCRIPTION
The existing codes seems to be handling this correctly, so this simply
removes the CSS hiding the delete button and makes sure that the display
does not hang around for the next rule.

I saw this was listed as a good first bug and jumped in. If this was an inappropriate task to pick up or there's something else I should have worked on let me know, I'm more than happy to shift gears.

resolves #564