### PR TITLE
Small improvements for addon development

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -149,7 +149,7 @@ input[type='email'] {
   user-select: none;
   outline: 0;
   z-index: 100;
-  cursor: default;
+  cursor: pointer;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
@@ -277,7 +277,7 @@ h6 {
 #back-button {
   top: 2rem;
   left: 2rem;
-  z-index: 0;
+  z-index: 2;
 }
 
 #menu-button.menu-shown {
@@ -363,6 +363,7 @@ h6 {
   font-size: 1.6rem;
   color: #fff;
   overflow: auto;
+  z-index:4;
 }
 
 .dialog.hidden {


### PR DESCRIPTION
By giving the layers in the first level of the dom a little more breathingroom, addons can...
- more easily do things like show full screen interactive content without overriding the top-left menu button, by using z-index 1. E.g. a fullscreen video player that still has the menu button on top.
- even override the menu button if need be, by using z-index 3. E.g the photo-frame addon, which shows the main menu when the user clicks anywhere on the screen.

This makes it easier to UI extension addons to co-exist without needing their own complicated CSS hacks.