### PR TITLE
Fix update-addons - closes #3197

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ import path from 'path';
 import expressHandlebars from 'express-handlebars';
 import ipRegex from 'ip-regex';
 import * as SegfaultHandler from 'segfault-handler';
+import { Device as DeviceSchema } from 'gateway-addon/lib/schema';
 
 // Keep these imports here to prevent circular dependencies
 import './plugin/outlet-proxy';
@@ -45,6 +46,7 @@ import Router from './router';
 import RulesController from './controllers/rules_controller';
 import sleep from './sleep';
 import Things from './models/things';
+import { ThingDescription } from './models/thing';
 import TunnelService from './tunnel-service';
 import { WiFiSetupApp, isWiFiConfigured } from './wifi-setup';
 import { AddressInfo } from 'net';
@@ -400,3 +402,18 @@ TunnelService.switchToHttps = () => {
     }
   });
 };
+
+AddonManager.on(Constants.THING_ADDED, (thing: ThingDescription) => {
+  Things.handleNewThing(thing);
+});
+
+AddonManager.on(Constants.THING_REMOVED, (thing: DeviceSchema) => {
+  Things.handleThingRemoved(thing);
+});
+
+AddonManager.on(
+  Constants.CONNECTED,
+  ({ device, connected }: { device: DeviceSchema; connected: boolean }) => {
+    Things.handleConnected(device.id, connected);
+  }
+);

--- a/src/models/things.ts
+++ b/src/models/things.ts
@@ -499,21 +499,4 @@ class Things extends EventEmitter {
   }
 }
 
-const instance = new Things();
-
-AddonManager.on(Constants.THING_ADDED, (thing: ThingDescription) => {
-  instance.handleNewThing(thing);
-});
-
-AddonManager.on(Constants.THING_REMOVED, (thing: DeviceSchema) => {
-  instance.handleThingRemoved(thing);
-});
-
-AddonManager.on(
-  Constants.CONNECTED,
-  ({ device, connected }: { device: DeviceSchema; connected: boolean }) => {
-    instance.handleConnected(device.id, connected);
-  }
-);
-
-export default instance;
+export default new Things();

--- a/tools/update-addons.js
+++ b/tools/update-addons.js
@@ -1,8 +1,8 @@
-const migrate = require('../build/migrate');
-const db = require('../build/db');
+const migrate = require('../build/migrate').default;
+const db = require('../build/db').default;
 db.open();
 
-const AddonManager = require('../build/addon-manager');
+const AddonManager = require('../build/addon-manager').default;
 
 migrate()
   .then(() => {


### PR DESCRIPTION
Fixes a problem with a circular dependency which can cause `AddonManager` to be undefined when `AddonManager.on()` is called in Things.ts.