### PR TITLE
balenaOS network settings - closes #3202

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,12 @@ RUN set -x && \
     usermod -a -G sudo,dialout,gpio node && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-COPY --chown=node:node . /home/node/webthings/gateway/
+COPY --chown=root:root . /root/webthings/gateway/
 RUN pipx install cookiecutter && \
     pipx runpip cookiecutter install -r \
-    /home/node/webthings/gateway/requirements.txt
+    /root/webthings/gateway/requirements.txt
 
-USER node
-WORKDIR /home/node/webthings/gateway
+WORKDIR /root/webthings/gateway
 RUN set -x && \
     CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm ci && \
     npm run build && \
@@ -55,8 +54,8 @@ RUN set -x && \
         config/default.js
 
 USER root
-RUN cp /home/node/webthings/gateway/tools/udevadm /bin/udevadm && \
-    cp /home/node/webthings/gateway/docker/avahi-daemon.conf /etc/avahi/ && \
-    cp /home/node/webthings/gateway/docker/init.sh /
+RUN cp /root/webthings/gateway/tools/udevadm /bin/udevadm && \
+    cp /root/webthings/gateway/docker/avahi-daemon.conf /etc/avahi/ && \
+    cp /root/webthings/gateway/docker/init.sh /
 
 ENTRYPOINT ["/init.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,16 @@ services:
     #  - "4443:4443"
     environment:
       - "TZ=America/Los_Angeles"
+      - "DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket"
     volumes:
-      - webthings-data:/home/node/.webthings
+      - webthings-data:/root/.webthings
     logging:
       driver: "json-file"
       options:
         max-size: "1m"
         max-file: "10"
+    labels:
+      io.balena.features.dbus: '1'
     # If certain devices are needed, e.g. USB dongles, enable them here.
     #devices:
     #  - /dev/ttyUSB0:/dev/ttyUSB0

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -19,13 +19,14 @@ if [[ "$WEBTHINGS_HOME" == "$HOME/.webthings" &&
 fi
 
 # If .webthings directory doesn't exist then create it
-if [[ ! -e /home/node/.webthings ]]; then
-    mkdir -p /home/node/.webthings
+if [[ ! -e /root/.webthings ]]; then
+    mkdir -p /root/.webthings
 fi
 
-# Give the Node user access to the .webthings data directory
-chown -R node:node /home/node/.webthings
+# Make sure the root user owns the .webthings data directory
+chown -R root:root /root/.webthings
 
 # Run the gateway
-export WEBTHINGS_HOME=/home/node/.webthings
-su node -c "cd /home/node/webthings/gateway && ./run-app.sh"
+export WEBTHINGS_HOME=/root/.webthings
+#su node -c "cd /home/node/webthings/gateway && ./run-app.sh"
+cd /root/webthings/gateway && ./run-app.sh

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -15,6 +15,7 @@ import LinuxDebianPlatform from './platforms/linux-debian';
 import LinuxRaspbianPlatform from './platforms/linux-raspbian';
 import LinuxUbuntuPlatform from './platforms/linux-ubuntu';
 import LinuxUbuntuCorePlatform from './platforms/linux-ubuntu-core';
+import LinuxBalenaOSPlatform from './platforms/linux-balena-os';
 import {
   LanMode,
   NetworkAddresses,
@@ -38,14 +39,62 @@ import {
  *                        * linux-debian
  *                        * linux-raspbian
  *                        * linux-ubuntu
+ *                        * linux-ubuntu-core
+ *                        * linux-balena-os
  *                        * linux-unknown
  */
 export function getOS(): string {
+  // Check for non-Linux operating systems
   const platform = process.platform;
   if (platform !== 'linux') {
     return platform;
   }
 
+  // Check if we're running inside a container
+  if (isContainer()) {
+    // Check for Balena as host OS
+    if (process.env.BALENA == '1') {
+      return 'linux-balena-os';
+    }
+  }
+
+  // Check if we're running inside the snap package
+  if (isSnap()) {
+    // Try to detect Ubuntu or Ubuntu Core from inside a snap
+    try {
+      const osReleaseLines = fs
+        .readFileSync('/var/lib/snapd/hostfs/etc/os-release', {
+          encoding: 'utf8',
+        })
+        .split('\n');
+      // Iterate through the file
+      for (let line of osReleaseLines) {
+        // Trim whitespace
+        line = line.trim();
+        // Find the line containing ID
+        if (line.startsWith('ID=')) {
+          // Get the value of the ID
+          let id = line.substring(3, line.length);
+          // Remove any quotation marks
+          id = id.replace(/"/g, '');
+          switch (id) {
+            case 'ubuntu':
+              return 'linux-ubuntu';
+            case 'ubuntu-core':
+              return 'linux-ubuntu-core';
+            default:
+              console.log('Running inside snap but unable to detect host OS');
+              return 'linux-ubuntu-unknown';
+          }
+        }
+      }
+    } catch (error) {
+      console.log(`Error trying to read os-release file from inside snap: ${error}`);
+      console.log('Check that the system-observe interface is connected');
+    }
+  }
+
+  // Check lsb_release for the name of a Linux distribution
   const proc = child_process.spawnSync('lsb_release', ['-i', '-s']);
   if (proc.status === 0) {
     const lsb_release = proc.stdout.toString().trim();
@@ -59,50 +108,11 @@ export function getOS(): string {
       case 'Ubuntu':
         return 'linux-ubuntu';
       default:
-        break;
+        return 'linux-unknown';
     }
-  }
-
-  // If not running inside a snap, give up at this point.
-  if (!isSnap()) {
-    console.log('Unknown Linux distribution');
+  } else {
     return 'linux-unknown';
   }
-
-  // Otherwise try to detect Ubuntu or Ubuntu Core from inside a snap
-  try {
-    const osReleaseLines = fs
-      .readFileSync('/var/lib/snapd/hostfs/etc/os-release', {
-        encoding: 'utf8',
-      })
-      .split('\n');
-    // Iterate through the file
-    for (let line of osReleaseLines) {
-      // Trim whitespace
-      line = line.trim();
-      // Find the line containing ID
-      if (line.startsWith('ID=')) {
-        // Get the value of the ID
-        let id = line.substring(3, line.length);
-        // Remove any quotation marks
-        id = id.replace(/"/g, '');
-        switch (id) {
-          case 'ubuntu':
-            return 'linux-ubuntu';
-          case 'ubuntu-core':
-            return 'linux-ubuntu-core';
-          default:
-            console.log('Unknown host Linux distribution');
-            break;
-        }
-      }
-    }
-  } catch (error) {
-    console.log(`Error trying to read os-release file: ${error}`);
-    console.log('Check that the system-observe interface is connected');
-  }
-
-  return 'linux-unknown';
 }
 
 /**
@@ -202,6 +212,9 @@ switch (getOS()) {
     break;
   case 'linux-ubuntu-core':
     platform = LinuxUbuntuCorePlatform;
+    break;
+  case 'linux-balena-os':
+    platform = LinuxBalenaOSPlatform;
     break;
   default:
     platform = null;

--- a/src/platforms/linux-balena-os.ts
+++ b/src/platforms/linux-balena-os.ts
@@ -1,0 +1,301 @@
+/**
+ * Balena OS platform interface.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import ip from 'ip';
+import { Netmask } from 'netmask';
+import BasePlatform from './base';
+import NetworkManager, { ConnectionSettings } from './utilities/network-manager';
+import { LanMode, NetworkAddresses, WirelessNetwork } from './types';
+
+export class LinuxBalenaOSPlatform extends BasePlatform {
+  /**
+   * Disconnect NetworkManager.
+   */
+  stop(): void {
+    NetworkManager.stop();
+  }
+
+  /**
+   * Get the current addresses for Wi-Fi and LAN.
+   *
+   * @returns {Promise<NetworkAddresses>} Promise that resolves with
+   *   {
+   *     lan: '...',
+   *     wlan: {
+   *      ip: '...',
+   *      ssid: '...',
+   *    }
+   *  }
+   */
+  async getNetworkAddressesAsync(): Promise<NetworkAddresses> {
+    const result: NetworkAddresses = {
+      lan: '',
+      wlan: {
+        ip: '',
+        ssid: '',
+      },
+    };
+    try {
+      const ethernetDevices = await NetworkManager.getEthernetDevices();
+      const ethernetIp4Config = await NetworkManager.getDeviceIp4Config(ethernetDevices[0]);
+      result.lan = ethernetIp4Config[0].address;
+    } catch (error) {
+      console.error(error);
+      console.log('Unable to detect an Ethernet IP address');
+    }
+    try {
+      const wifiDevices = await NetworkManager.getWifiDevices();
+      const wifiIp4Config = await NetworkManager.getDeviceIp4Config(wifiDevices[0]);
+      const accessPoint = await NetworkManager.getActiveAccessPoint(wifiDevices[0]);
+      const ssid = await NetworkManager.getAccessPointSsid(accessPoint);
+      result.wlan.ip = wifiIp4Config[0].address;
+      result.wlan.ssid = ssid;
+    } catch (error) {
+      console.error(error);
+      console.log('Unable to detect a Wi-Fi IP address and active SSID');
+    }
+    return result;
+  }
+
+  /**
+   * Get LAN network settings.
+   *
+   * @returns {Promise<LanMode>} Promise that resolves with
+   *   {mode: 'static|dhcp|...', options: {...}}
+   */
+  async getLanModeAsync(): Promise<LanMode> {
+    const result: LanMode = {
+      mode: '',
+      options: {},
+    };
+    return NetworkManager.getEthernetDevices()
+      .then((devices) => {
+        return NetworkManager.getDeviceConnection(devices[0]);
+      })
+      .then((connection) => {
+        return NetworkManager.getConnectionSettings(connection);
+      })
+      .then((settings: ConnectionSettings) => {
+        if (settings && settings.ipv4 && settings.ipv4.method == 'auto') {
+          result.mode = 'dhcp';
+        } else if (settings && settings.ipv4 && settings.ipv4.method == 'manual') {
+          result.mode = 'static';
+        }
+        if (settings.ipv4 && settings.ipv4['address-data'] && settings.ipv4['address-data'][0]) {
+          if (settings.ipv4['address-data'][0].hasOwnProperty('address')) {
+            result.options.ipaddr = settings.ipv4['address-data'][0].address;
+          }
+          if (result.options.ipaddr && settings.ipv4['address-data'][0].hasOwnProperty('prefix')) {
+            // Convert cidr style prefix to dot-decimal netmask
+            const ip = result.options.ipaddr;
+            const cidr = settings.ipv4['address-data'][0].prefix;
+            const block = new Netmask(`${ip}/${cidr}`);
+            result.options.netmask = block.mask;
+          }
+        }
+        if (settings.ipv4 && settings.ipv4.hasOwnProperty('gateway')) {
+          result.options.gateway = settings.ipv4.gateway;
+        }
+        return result;
+      })
+      .catch((error) => {
+        console.error(`Error getting LAN mode from Network Manager: ${error}`);
+        return result;
+      });
+  }
+
+  /**
+   * Set LAN network settings.
+   *
+   * @param {string} mode static|dhcp|....
+   * @param {Record<string, unknown>} options Mode-specific options.
+   * @returns {Promise<boolean>} Promise that resolves true if successful and false if not.
+   */
+  async setLanModeAsync(mode: string, options: Record<string, unknown>): Promise<boolean> {
+    let lanDevice: string;
+    let lanConnection: string;
+    return NetworkManager.getEthernetDevices()
+      .then((devices) => {
+        lanDevice = devices[0];
+        return NetworkManager.getDeviceConnection(lanDevice);
+      })
+      .then((connection) => {
+        lanConnection = connection;
+        // First get current settings to carry over some values
+        return NetworkManager.getConnectionSettings(lanConnection);
+      })
+      .then((oldSettings) => {
+        // Carry over some values from the old settings
+        const settings: ConnectionSettings = {
+          connection: {
+            id: oldSettings.connection.id,
+            uuid: oldSettings.connection.uuid,
+            type: oldSettings.connection.type,
+          },
+        };
+
+        if (mode == 'dhcp') {
+          // Set dynamic IP
+          settings.ipv4 = {
+            method: 'auto',
+          };
+        } else if (mode == 'static') {
+          if (
+            !(
+              options.hasOwnProperty('ipaddr') &&
+              ip.isV4Format(<string>options.ipaddr) &&
+              options.hasOwnProperty('gateway') &&
+              ip.isV4Format(<string>options.gateway) &&
+              options.hasOwnProperty('netmask') &&
+              ip.isV4Format(<string>options.netmask)
+            )
+          ) {
+            console.log(
+              'Setting a static IP address requires a valid IP address, gateway and netmask'
+            );
+            return false;
+          }
+          // Set static IP address
+          // Convert dot-decimal netmask to cidr style prefix for storage
+          const netmask = new Netmask(options.ipaddr as string, options.netmask as string);
+          const prefix = netmask.bitmask;
+          // Convert dot-decimal IP and gateway to little endian integers for storage
+          const ipaddrReversed = (options.ipaddr as string).split('.').reverse().join('.');
+          const ipaddrInt = ip.toLong(ipaddrReversed);
+          const gatewayReversed = (options.gateway as string).split('.').reverse().join('.');
+          const gatewayInt = ip.toLong(gatewayReversed);
+          settings.ipv4 = {
+            method: 'manual',
+            addresses: [[ipaddrInt, prefix, gatewayInt]],
+            // The NetworkManager docs say that the addresses property is deprecated,
+            // but using address-data and gateway doesn't seem to work on Ubuntu yet.
+            /*
+            'address-data': [{
+              'address': options.ipaddr,
+              'prefix': prefix
+            }],
+            'gateway': options.gateway
+            */
+          };
+        } else {
+          console.error('LAN mode not recognised');
+          return false;
+        }
+        return NetworkManager.setConnectionSettings(lanConnection, settings);
+      })
+      .then(() => {
+        return NetworkManager.activateConnection(lanConnection, lanDevice);
+      })
+      .catch((error) => {
+        console.error(`Error setting LAN settings: ${error}`);
+        return false;
+      });
+  }
+
+  /**
+   * Scan for visible wireless networks on the first wireless device.
+   *
+   * @returns {Promise<WirelessNetwork[]>} Promise which resolves with an array
+   *   of networks as objects:
+   *  [
+   *    {
+   *      ssid: '...',
+   *      quality: <number>,
+   *      encryption: true|false,
+   *      configured: true|false,
+   *      connected: true|false
+   *    },
+   *    ...
+   *  ]
+   */
+  async scanWirelessNetworksAsync(): Promise<WirelessNetwork[]> {
+    const wifiDevices = await NetworkManager.getWifiDevices();
+    const wifiAccessPoints = await NetworkManager.getWifiAccessPoints(wifiDevices[0]);
+    let activeAccessPoint: string | null;
+    try {
+      activeAccessPoint = await NetworkManager.getActiveAccessPoint(wifiDevices[0]);
+    } catch (error) {
+      activeAccessPoint = null;
+    }
+    const apRequests: Array<Promise<WirelessNetwork>> = [];
+    wifiAccessPoints.forEach((ap) => {
+      apRequests.push(NetworkManager.getAccessPointDetails(ap, activeAccessPoint));
+    });
+    const responses = await Promise.all(apRequests);
+    return responses;
+  }
+
+  /**
+   * Set the wireless mode and options.
+   *
+   * @param {boolean} enabled - whether or not wireless is enabled
+   * @param {string} mode - ap, sta, ...
+   * @param {Record<string, unknown>} options - options specific to wireless mode
+   * @returns {Promise<boolean>} Boolean indicating success.
+   */
+  async setWirelessModeAsync(
+    enabled: boolean,
+    mode = 'ap',
+    options: Record<string, unknown> = {}
+  ): Promise<boolean> {
+    const valid = [
+      // 'ap', //TODO: Implement ap mode
+      'sta',
+    ];
+    if (enabled && !valid.includes(mode)) {
+      console.error(`Wireless mode ${mode} not supported on this platform`);
+      return false;
+    }
+    const wifiDevices = await NetworkManager.getWifiDevices();
+
+    // If `enabled` set to false, disconnect wireless device
+    if (enabled === false) {
+      // Return false if no wifi device found
+      if (!wifiDevices[0]) {
+        return false;
+      }
+      try {
+        await NetworkManager.disconnectNetworkDevice(wifiDevices[0]);
+      } catch (error) {
+        console.error(`Error whilst attempting to disconnect wireless device: ${error}`);
+        return false;
+      }
+      return true;
+    }
+
+    // Otherwise connect to Wi-Fi access point using provided options
+    if (!options.hasOwnProperty('ssid')) {
+      console.log('Could not connect to wireless network because no SSID provided');
+      return false;
+    }
+    const accessPoint = await NetworkManager.getAccessPointbySsid(options.ssid as string);
+    if (accessPoint == null) {
+      console.log('No network with specified SSID found');
+      return false;
+    }
+    let secure = false;
+    if (options.key) {
+      secure = true;
+    }
+    try {
+      NetworkManager.connectToWifiAccessPoint(
+        wifiDevices[0],
+        accessPoint,
+        <string>options.ssid,
+        secure,
+        <string>options.key
+      );
+    } catch (error) {
+      console.error(`Error connecting to Wi-Fi access point: ${error}`);
+      return false;
+    }
+    return true;
+  }
+}
+
+export default new LinuxBalenaOSPlatform();

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -838,6 +838,7 @@ const SettingsScreen = {
           case 'linux-raspbian':
           case 'linux-ubuntu':
           case 'linux-ubuntu-core':
+          case 'linux-balena-os':
             this.elements.network.client.main.classList.remove('hidden');
             break;
           default:


### PR DESCRIPTION
Closes #3202.

This PR enables network settings on balenaOS by giving the Docker image access to NetworkManager on the host via DBus. It re-uses the NetworkManager back end created for Ubuntu Core by balenaOS, and enables network settings in the front end when balenaOS is detected.

Unfortunately in order for this to work the gateway application has to run as root inside the Docker container, rather than the non-root node user it is currently using. I'm nervous about doing this because it increases the risk of privilege escalation, but having spent a lot of time [looking into this](https://forums.balena.io/t/unable-to-access-networkmanager-via-dbus/374801) (and getting other people to look into it) there isn't an easy alternative.

Essentially balenaOS as a host OS is designed to be immutable and whilst there is a mechanism for containers to access the DBus system bus, the way that DBus and PolicyKit are configured on the host means that any messages from a non-root user will not get through. 

Short of re-architecting the whole gateway application into separate services (which we might actually want to consider for the future) or running a DBus proxy of some kind, I'm really not sure what else we can do.

It's not ideal to force existing users of the Docker image to migrate to running the gateway as root inside the container so that it will work on balenaOS, but note that the gateway does currently run as root on the Raspbian image, and technically runs as root on Ubuntu Core as well because it's a daemon. (I think Docker users could still run as node if they start the container themselves rather than using docker-compose).