### PR TITLE
Give Docker container access to first USB device by default - closes #3204

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,9 @@ services:
         max-file: "10"
     labels:
       io.balena.features.dbus: '1'
-    # If certain devices are needed, e.g. USB dongles, enable them here.
-    #devices:
-    #  - /dev/ttyUSB0:/dev/ttyUSB0
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0
+    # If other devices are needed, e.g. USB dongles, enable them here.
     #  - /dev/ttyACM0:/dev/ttyACM0
     # If Bluetooth, the container needs to run in privileged mode.
     #privileged: true


### PR DESCRIPTION
Giving add-ons access to all serial ports without also giving them access to a lot of other stuff they don't need is going to be tricky. Ideally add-ons would have access to all serial devices and support hotplug to dynamically map them into the Docker container, but that is going to be tricky.

How about as a starting point we just hard code access to `/dev/ttyUSB0` by default in docker-compose? That should hopefully allow add-ons access to the first serial device connected via USB (e.g. a Zigbee or Z-Wave dongle), which in many cases will be all the user needs. Users can manually add and remove devices in docker-compose.yml, or manually start Docker with their own settings.

Is that reasonable?

Closes #3204 (kind of).