### PR TITLE
Fix Thing names in rules engine UI - closes #3183

### DIFF
--- a/static/js/rules/RuleUtils.js
+++ b/static/js/rules/RuleUtils.js
@@ -30,9 +30,16 @@ const RuleUtils = {
       console.warn('byProperty property undefined', new Error().stack);
       return false;
     }
-
+    const propHref = `/things/${encodeURIComponent(property.thing)}/properties/${encodeURIComponent(
+      property.id
+    )}`;
     const optProp = option.properties[property.id];
-    return optProp && optProp.forms && optProp.forms.length;
+    return (
+      optProp &&
+      optProp.forms.filter((f) => {
+        return f.href === propHref;
+      }).length > 0
+    );
   },
   // Helper function for selecting the thing corresponding to an href
   byThing: (thing) => (otherThing) => {


### PR DESCRIPTION
This PR replaces some logic that was removed from a filtering function in RuleUtils.js in #2811 which is used to identify which Thing a Property belongs to.

This should fix the UI bugs that were reported in #3183.