### PR TITLE
Temporarily fork node-getopt to fix error on command line - closes #3232

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "netmask": "^2.0.2",
         "nocache": "^2.1.0",
         "node-fetch": "^2.6.7",
-        "node-getopt": "^0.3.2",
+        "node-getopt": "git://github.com/WebThingsIO/node-getopt.git",
         "promisepipe": "^3.0.0",
         "rimraf": "^3.0.2",
         "segfault-handler": "^1.3.0",
@@ -15568,8 +15568,7 @@
     },
     "node_modules/node-getopt": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
-      "integrity": "sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q==",
+      "resolved": "git+ssh://git@github.com/WebThingsIO/node-getopt.git#138567c009614fc6322bfd93f1b79523a60f0cc4",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "netmask": "^2.0.2",
     "nocache": "^2.1.0",
     "node-fetch": "^2.6.7",
-    "node-getopt": "^0.3.2",
+    "node-getopt": "git://github.com/WebThingsIO/node-getopt.git",
     "promisepipe": "^3.0.0",
     "rimraf": "^3.0.2",
     "segfault-handler": "^1.3.0",


### PR DESCRIPTION
This is a temporary workaround for #3232 by forking the unmaintained node-getopt package with a patch.

The long term fix of replacing the package will be tracked in #3231 but I don't want to block the 2.0.0 release on researching an alternative.