### PR TITLE
Disable mDNS checkbox outside Raspbian and allow async domain settings - closes #3257

### DIFF
--- a/src/controllers/settings_controller.ts
+++ b/src/controllers/settings_controller.ts
@@ -153,7 +153,9 @@ function build(): express.Router {
   controller.get('/domain', auth, async (_request, response) => {
     try {
       let hostname = '';
-      if (Platform.implemented('getHostname')) {
+      if (Platform.implemented('getHostnameAsync')) {
+        hostname = await Platform.getHostnameAsync();
+      } else if (Platform.implemented('getHostname')) {
         hostname = Platform.getHostname();
       }
 
@@ -189,7 +191,25 @@ function build(): express.Router {
     try {
       if (request.body.hasOwnProperty('hostname')) {
         const hostname = <string>request.body.hostname;
-        if (!Platform.implemented('setHostname') || !Platform.setHostname(hostname)) {
+
+        if (Platform.implemented('setHostnameAsync')) {
+          try {
+            const success = await Platform.setHostnameAsync(hostname);
+            if (!success) {
+              response.sendStatus(500);
+              return;
+            }
+          } catch (error) {
+            response.sendStatus(500);
+            return;
+          }
+        } else if (Platform.implemented('setHostname')) {
+          const success = Platform.setHostname(hostname);
+          if (!success) {
+            response.sendStatus(500);
+            return;
+          }
+        } else {
           response.sendStatus(500);
           return;
         }
@@ -218,7 +238,9 @@ function build(): express.Router {
       }
 
       let domain = '';
-      if (Platform.implemented('getHostname')) {
+      if (Platform.implemented('getHostnameAsync')) {
+        domain = await Platform.getHostnameAsync();
+      } else if (Platform.implemented('getHostname')) {
         domain = Platform.getHostname();
       }
 
@@ -239,7 +261,9 @@ function build(): express.Router {
       console.error(`Failed setting domain with: ${err} `);
 
       let domain = '';
-      if (Platform.implemented('getHostname')) {
+      if (Platform.implemented('getHostnameAsync')) {
+        domain = await Platform.getHostnameAsync();
+      } else if (Platform.implemented('getHostname')) {
         domain = Platform.getHostname();
       }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -211,7 +211,9 @@ switch (getOS()) {
 export const getDhcpServerStatus = wrapPlatform<boolean>(platform, 'getDhcpServerStatus');
 export const setDhcpServerStatus = wrapPlatform<boolean>(platform, 'setDhcpServerStatus');
 export const getHostname = wrapPlatform<string>(platform, 'getHostname');
+export const getHostnameAsync = wrapPlatform<Promise<string>>(platform, 'getHostnameAsync');
 export const setHostname = wrapPlatform<boolean>(platform, 'setHostname');
+export const setHostnameAsync = wrapPlatform<Promise<boolean>>(platform, 'setHostnameAsync');
 export const getLanMode = wrapPlatform<LanMode>(platform, 'getLanMode');
 export const getLanModeAsync = wrapPlatform<Promise<LanMode>>(platform, 'getLanModeAsync');
 export const setLanMode = wrapPlatform<boolean>(platform, 'setLanMode');

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -778,6 +778,21 @@ const SettingsScreen = {
         this.elements.domain.update.disabled = true;
       }
     });
+
+    API.getPlatform().then((body) => {
+      switch (body.os) {
+        // Currently mDNS can only be toggle on and off on Raspbian, so
+        // disable the checkbox on other platforms
+        case 'linux-raspbian':
+          this.elements.domain.localCheckbox.disabled = false;
+          break;
+        default:
+          this.elements.domain.localCheckbox.disabled = true;
+          break;
+      }
+
+      return API.getNetworkAddresses();
+    });
   },
 
   onLocalDomainCheckboxChange: (e) => {


### PR DESCRIPTION
Closes #3257

Also includes supporting async local domain settings which is needed downstream but may be useful for other platforms.