### PR TITLE
Fix update settings UI on platforms where updates not configurable

### DIFF
--- a/src/controllers/updates_controller.ts
+++ b/src/controllers/updates_controller.ts
@@ -177,10 +177,23 @@ function build(): express.Router {
   });
 
   controller.get('/self-update', async (_request, response) => {
+    // If the gateway is running inside a snap then auto updates are always
+    // enabled and can not be manually triggered from the UI
+    if (Platform.isSnap()) {
+      response.json({
+        available: true,
+        enabled: true,
+        configurable: false,
+        triggerable: false,
+      });
+      return;
+    }
     if (!Platform.implemented('getSelfUpdateStatus')) {
       response.json({
         available: false,
         enabled: false,
+        configurable: false,
+        triggerable: false,
       });
     } else {
       response.json(Platform.getSelfUpdateStatus());

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -60,6 +60,8 @@ class DarwinPlatform extends BasePlatform {
     return {
       available: false,
       enabled: false,
+      configurable: false,
+      triggerable: false,
     };
   }
 

--- a/src/platforms/linux-arch.ts
+++ b/src/platforms/linux-arch.ts
@@ -45,6 +45,8 @@ class LinuxArchPlatform extends BasePlatform {
     return {
       available: false,
       enabled: false,
+      configurable: false,
+      triggerable: false,
     };
   }
 

--- a/src/platforms/linux-debian.ts
+++ b/src/platforms/linux-debian.ts
@@ -20,6 +20,8 @@ export class LinuxDebianPlatform extends BasePlatform {
     return {
       available: false,
       enabled: false,
+      configurable: false,
+      triggerable: false,
     };
   }
 

--- a/src/platforms/linux-raspbian.ts
+++ b/src/platforms/linux-raspbian.ts
@@ -799,6 +799,8 @@ class LinuxRaspbianPlatform extends BasePlatform {
     return {
       available: timerExists,
       enabled: proc.status === 0,
+      configurable: true,
+      triggerable: true,
     };
   }
 

--- a/src/platforms/linux-ubuntu-core.ts
+++ b/src/platforms/linux-ubuntu-core.ts
@@ -10,7 +10,7 @@ import ip from 'ip';
 import { Netmask } from 'netmask';
 import BasePlatform from './base';
 import NetworkManager, { ConnectionSettings } from './utilities/network-manager';
-import { LanMode, NetworkAddresses, WirelessNetwork } from './types';
+import { LanMode, NetworkAddresses, WirelessNetwork, SelfUpdateStatus } from './types';
 
 export class LinuxUbuntuCorePlatform extends BasePlatform {
   /**
@@ -293,6 +293,27 @@ export class LinuxUbuntuCorePlatform extends BasePlatform {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Determine whether or not the gateway can auto-update itself.
+   *
+   * @returns {Object} {
+   *                      available: <bool>,
+   *                      enabled: <bool>,
+   *                      configurable: <bool>,
+   *                      triggerable: <bool>
+   *                   }
+   */
+  getSelfUpdateStatus(): SelfUpdateStatus {
+    // Automatic updates are supported on Ubuntu Core but can not be disabled
+    // or manually triggered from the UI
+    return {
+      available: true,
+      enabled: true,
+      configurable: false,
+      triggerable: false,
+    };
   }
 }
 

--- a/src/platforms/linux-ubuntu.ts
+++ b/src/platforms/linux-ubuntu.ts
@@ -7,7 +7,29 @@
  */
 
 import { LinuxUbuntuCorePlatform } from './linux-ubuntu-core';
+import { SelfUpdateStatus } from './types';
 
-class LinuxUbuntuPlatform extends LinuxUbuntuCorePlatform {}
+class LinuxUbuntuPlatform extends LinuxUbuntuCorePlatform {
+  /**
+   * Determine whether or not the gateway can auto-update itself.
+   *
+   * @returns {Object} {
+   *                      available: <bool>,
+   *                      enabled: <bool>,
+   *                      configurable: <bool>,
+   *                      triggerable: <bool>
+   *                   }
+   */
+  getSelfUpdateStatus(): SelfUpdateStatus {
+    // Automatic updates are not supported on Ubuntu
+    // (snaps are detected separately in Platform.ts)
+    return {
+      available: false,
+      enabled: false,
+      configurable: false,
+      triggerable: false,
+    };
+  }
+}
 
 export default new LinuxUbuntuPlatform();

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -1,6 +1,8 @@
 export interface SelfUpdateStatus {
-  available: boolean;
-  enabled: boolean;
+  available: boolean; // Automatic updates are possible
+  enabled: boolean; // Automatic updates are enabled
+  configurable: boolean; // Automatic updates can be turned on and off
+  triggerable: boolean; // Updates can be manually triggered by the user
 }
 
 export interface LanMode {

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -751,7 +751,8 @@
   background-image: url('/images/authorization.svg');
 }
 
-#update-now.hidden {
+#update-now.hidden,
+#up-to-date-container.hidden {
   display: none;
 }
 

--- a/static/js/views/settings.js
+++ b/static/js/views/settings.js
@@ -1437,6 +1437,7 @@ const SettingsScreen = {
   },
 
   fetchUpdateInfo: function () {
+    const upToDateContainerElt = document.getElementById('up-to-date-container');
     const upToDateElt = document.getElementById('update-settings-up-to-date');
     const updateNow = document.getElementById('update-now');
     const versionElt = document.getElementById('update-settings-version');
@@ -1467,7 +1468,8 @@ const SettingsScreen = {
       }
 
       this.elements.update.enableSelfUpdatesCheckbox.checked = support.enabled;
-      this.elements.update.enableSelfUpdatesCheckbox.disabled = !support.available;
+      this.elements.update.enableSelfUpdatesCheckbox.disabled =
+        !support.available || !support.configurable;
 
       if (support.available) {
         statusElt.textContent = statusText;
@@ -1475,7 +1477,9 @@ const SettingsScreen = {
         statusElt.classList.add('hidden');
       }
 
-      if (support.available) {
+      if (support.available && !support.triggerable) {
+        upToDateContainerElt.classList.add('hidden');
+      } else if (support.available) {
         upToDateElt.textContent = fluent.getMessage('checking-for-updates');
         updateNow.classList.add('hidden');
 


### PR DESCRIPTION
Currently the update settings UI does not really account for platforms (like Ubuntu Core) where automatic updates are enabled but are not user configurable or triggerable from the UI.

This PR adds a bit more nuance to the update settings UI so that it can accurately represent the status of that kind of platform.