### PR TITLE
Fix Docker image and bump version to 2.1.0-beta.2 - closes #3286

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ USER node
 WORKDIR /home/node/webthings/gateway
 RUN set -x && \
     CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm ci && \
+    npm rebuild sqlite3 --build-from-source && \
     npm run build && \
     rm -rf ./node_modules/gifsicle && \
     rm -rf ./node_modules/mozjpeg && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webthings-gateway",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webthings-gateway",
-      "version": "2.1.0-beta.1",
+      "version": "2.1.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@fluent/bundle": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "Web of Things gateway",
   "main": "build/app.js",
   "scripts": {


### PR DESCRIPTION
This PR:
- Fixes gateway build in Docker image by re-building the sqlite3 binaries for the version of glibc shipped with the image
- Bumps the version of the gateway to 2.1.0-beta.2