### PR TITLE
Allow pushing WS messages directly to addons

### DIFF
--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -128,6 +128,21 @@ class ThingModel extends Model {
       if (message.hasOwnProperty('id') && message.id !== this.id) {
         return;
       }
+      if (typeof window.snoop_thing != 'undefined' && 
+         typeof window.snoop_thing[this.id] == 'object' && 
+         Array.isArray(window.snoop_thing[this.id])
+      ) {
+        for (let f = 0; f < window.snoop_thing[this.id].length; f++) {
+          if (typeof window.snoop_thing[this.id][f] === 'function') {
+            try {
+              window.snoop_thing[this.id][f](message);
+            }
+            catch (error) {
+              console.error(`thing-model.js: caught error passing message to thing id: ${this.id}, error: ${error}`);
+            }
+          }
+        }
+      }
       switch (message.messageType) {
         case 'propertyStatus':
           this.onPropertyStatus(message.data);

--- a/static/js/models/thing-model.js
+++ b/static/js/models/thing-model.js
@@ -128,17 +128,22 @@ class ThingModel extends Model {
       if (message.hasOwnProperty('id') && message.id !== this.id) {
         return;
       }
-      if (typeof window.snoop_thing != 'undefined' && 
-         typeof window.snoop_thing[this.id] == 'object' && 
-         Array.isArray(window.snoop_thing[this.id])
+      if (
+        typeof window.snoop_thing != 'undefined' &&
+        typeof this.id == 'string' &&
+        typeof window.snoop_thing[this.id] == 'object' &&
+        Array.isArray(window.snoop_thing[this.id])
       ) {
         for (let f = 0; f < window.snoop_thing[this.id].length; f++) {
           if (typeof window.snoop_thing[this.id][f] === 'function') {
             try {
               window.snoop_thing[this.id][f](message);
-            }
-            catch (error) {
-              console.error(`thing-model.js: caught error passing message to thing id: ${this.id}, error: ${error}`);
+            } catch (err) {
+              console.error(
+                'thing-model: caught error passing message to snoop_thing for this.id: ',
+                this.id,
+                err,
+              );
             }
           }
         }


### PR DESCRIPTION
This is probably not how you would implement this, but I thought I'd share as a conversation starter.

This little experiment has been incredibly useful as a light-weight method for addons to subscribe to things. It avoids addons having to create a new websocket client to get things data that is already being received in the browser window.

The Photo Frame addon [uses this to get event updates](https://github.com/flatsiedatsie/photo-frame/blob/7a53a382850cbd3fafa1cffeb259176c5a523c38/js/extension.js#L34). Now users can use their phone as a remote control for the Photo Frame.

I don't know if this breaks a security model. I figured that any addon can already read the key from window.API. And if the addon is loaded, that means the user is logged in. 

As someone who builds a lot of addons I love this. It replaces so much code and complexity around websocket management.