### PR TITLE
Simpler thing detail view

### DIFF
--- a/static/css/thing.css
+++ b/static/css/thing.css
@@ -71,11 +71,19 @@
   position: relative;
 }
 
-.thing-detail-contents {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+#things.single-thing > .thing {
+  width:100%;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#things.single-thing > .thing > * {
+  display: flex;
+  padding: 1rem;
+  min-height: 14rem;
+  min-width: 14rem;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 .thing-detail-label {

--- a/static/css/thing.css
+++ b/static/css/thing.css
@@ -79,7 +79,6 @@
 
 #things.single-thing > .thing > * {
   display: flex;
-  padding: 1rem;
   min-height: 14rem;
   min-width: 14rem;
   align-items: flex-start;

--- a/static/js/schema-impl/capability/thing.js
+++ b/static/js/schema-impl/capability/thing.js
@@ -419,11 +419,12 @@ class Thing {
         action.attached = true;
       }
     }
-
+    /*
     this.layout = new ThingDetailLayout(
       this,
       this.element.querySelectorAll('.thing-detail-container')
     );
+    */
   }
 
   /**


### PR DESCRIPTION
This replaces the 'octopus view' with a responsive grid-based design.

<img width="1292" height="2000" alt="Screenshot 2026-04-11 at 17 40 28" src="https://github.com/user-attachments/assets/66cb0e23-a5fb-47f8-9978-ffce35cc183c" />
